### PR TITLE
Added vesc submodule and functionality

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ros_ws/src/external_packages/vesc"]
+	path = ros_ws/src/external_packages/vesc
+	url = https://github.com/mit-racecar/vesc.git

--- a/ros_ws/launch/car-teleop.launch
+++ b/ros_ws/launch/car-teleop.launch
@@ -1,4 +1,5 @@
 <launch>
     <include file="$(find car_control)/launch/car_control.launch"/>
     <include file="$(find teleoperation)/launch/remote_control.launch"/>
+    <include file="$(find vesc_driver)/launch/vesc_driver_node.launch"/>
 </launch>


### PR DESCRIPTION
I've included the vesc package as a submodule and added the vesc_driver_node to our launch file.

Implements #73 

This is different to the previous pull request since it does not include the vesc_to_odom_node and does not need dummy variables. The integration of that node can happen later.