### PR TITLE
Reverse driving and an invert steering option for the gamepad controller

### DIFF
--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -9,6 +9,7 @@ constexpr int JOYSTICK_AXIS_STEERING = 0;
 constexpr int JOYSTICK_AXIS_THROTTLE = 5;
 constexpr int JOYSTICK_AXIS_REVERSE = 2;
 constexpr int JOYSTICK_BUTTON_DEADMANSSWITCH = 0;
+constexpr int JOYSTICK_BUTTON_TOGGLE_INVERT_STEERING = 2;
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
 
@@ -25,6 +26,8 @@ class JoystickController
     ros::Subscriber m_joystick_subscriber;
 
     bool m_invert_steering = false;
+    
+    bool m_toggle_invert_steering_state = false;
 
     void joystickCallback(const sensor_msgs::Joy::ConstPtr& joystick);
     void publishDriveParameters(double velocity, double steering_angle);

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -12,6 +12,8 @@ constexpr int JOYSTICK_BUTTON_DEADMANSSWITCH = 0;
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
 
+constexpr const char* INVERT_STEERING_PARAMETER = "invert_steering";
+
 class JoystickController
 {
     public:
@@ -21,6 +23,8 @@ class JoystickController
     ros::NodeHandle m_node_handle;
     ros::Publisher m_drive_parameter_publisher;
     ros::Subscriber m_joystick_subscriber;
+
+    bool m_invert_steering = false;
 
     void joystickCallback(const sensor_msgs::Joy::ConstPtr& joystick);
     void publishDriveParameters(double velocity, double steering_angle);

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -5,11 +5,12 @@
 #include <drive_msgs/drive_param.h>
 #include <sensor_msgs/Joy.h>
 
-#define JOYSTICK_AXIS_STEERING 0
-#define JOYSTICK_AXIS_THROTTLE 5
-#define JOYSTICK_BUTTON_DEADMANSSWITCH 0
+constexpr int JOYSTICK_AXIS_STEERING = 0;
+constexpr int  JOYSTICK_AXIS_THROTTLE = 5;
+constexpr int  JOYSTICK_AXIS_REVERSE = 2;
+constexpr int  JOYSTICK_BUTTON_DEADMANSSWITCH = 0;
 
-#define TOPIC_DRIVE_PARAMETERS "/set/drive_param"
+constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
 
 class JoystickController
 {

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -6,9 +6,9 @@
 #include <sensor_msgs/Joy.h>
 
 constexpr int JOYSTICK_AXIS_STEERING = 0;
-constexpr int  JOYSTICK_AXIS_THROTTLE = 5;
-constexpr int  JOYSTICK_AXIS_REVERSE = 2;
-constexpr int  JOYSTICK_BUTTON_DEADMANSSWITCH = 0;
+constexpr int JOYSTICK_AXIS_THROTTLE = 5;
+constexpr int JOYSTICK_AXIS_REVERSE = 2;
+constexpr int JOYSTICK_BUTTON_DEADMANSSWITCH = 0;
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
 
@@ -18,9 +18,9 @@ class JoystickController
     JoystickController();
 
     private:
-    ros::NodeHandle node_handle;
-    ros::Publisher drive_parameter_publisher;
-    ros::Subscriber joystick_subscriber;
+    ros::NodeHandle m_node_handle;
+    ros::Publisher m_drive_parameter_publisher;
+    ros::Subscriber m_joystick_subscriber;
 
     void joystickCallback(const sensor_msgs::Joy::ConstPtr& joystick);
     void publishDriveParameters(double velocity, double steering_angle);

--- a/ros_ws/src/teleoperation/launch/remote_control.launch
+++ b/ros_ws/src/teleoperation/launch/remote_control.launch
@@ -11,6 +11,7 @@ Launches all necessary nodes that let the user control the car with the keyboard
       type="joystick_controller"
       name="joystick_controller"
       output="log" >
+      <param name="invert_steering" type="bool" value ="true" />
     </node>
 
     <!-- joy node -->

--- a/ros_ws/src/teleoperation/launch/remote_control.launch
+++ b/ros_ws/src/teleoperation/launch/remote_control.launch
@@ -4,6 +4,8 @@
 Launches all necessary nodes that let the user control the car with the keyboard and/or gamepad.
 -->
 
+  <arg name="invert_steering" default="true"/>
+
     <!-- remote joy -->
     <node
       respawn="true"
@@ -11,7 +13,7 @@ Launches all necessary nodes that let the user control the car with the keyboard
       type="joystick_controller"
       name="joystick_controller"
       output="log" >
-      <param name="invert_steering" type="bool" value ="true" />
+      <param name="invert_steering" type="bool" value ="$(arg invert_steering)" />
     </node>
 
     <!-- joy node -->

--- a/ros_ws/src/teleoperation/src/joystick_controller.cpp
+++ b/ros_ws/src/teleoperation/src/joystick_controller.cpp
@@ -23,6 +23,7 @@ void JoystickController::joystickCallback(const sensor_msgs::Joy::ConstPtr& joys
 {
     double steering_angle = static_cast<double>(-joystick->axes[JOYSTICK_AXIS_STEERING]);
     double velocity = static_cast<double>(joystick->axes[JOYSTICK_AXIS_THROTTLE] - 1) * -0.5;
+    velocity -= static_cast<double>(joystick->axes[JOYSTICK_AXIS_REVERSE] - 1) * -0.5;
 
     this->publishDriveParameters(velocity, steering_angle);
 }

--- a/ros_ws/src/teleoperation/src/joystick_controller.cpp
+++ b/ros_ws/src/teleoperation/src/joystick_controller.cpp
@@ -5,10 +5,10 @@
  */
 JoystickController::JoystickController()
 {
-    this->drive_parameter_publisher = this->node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAMETERS, 1);
+    this->m_drive_parameter_publisher = this->m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAMETERS, 1);
 
-    this->joystick_subscriber =
-        this->node_handle.subscribe<sensor_msgs::Joy>("joy", 10, &JoystickController::joystickCallback, this);
+    this->m_joystick_subscriber =
+        this->m_node_handle.subscribe<sensor_msgs::Joy>("joy", 10, &JoystickController::joystickCallback, this);
 }
 
 /**
@@ -40,7 +40,7 @@ void JoystickController::publishDriveParameters(double velocity, double steering
     drive_parameters.velocity = velocity;
     drive_parameters.angle = steering_angle;
 
-    this->drive_parameter_publisher.publish(drive_parameters);
+    this->m_drive_parameter_publisher.publish(drive_parameters);
 }
 
 int main(int argc, char** argv)

--- a/ros_ws/src/teleoperation/src/joystick_controller.cpp
+++ b/ros_ws/src/teleoperation/src/joystick_controller.cpp
@@ -5,10 +5,14 @@
  */
 JoystickController::JoystickController()
 {
-    this->m_drive_parameter_publisher = this->m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAMETERS, 1);
+    this->m_drive_parameter_publisher =
+        this->m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAMETERS, 1);
 
     this->m_joystick_subscriber =
         this->m_node_handle.subscribe<sensor_msgs::Joy>("joy", 10, &JoystickController::joystickCallback, this);
+
+    ros::NodeHandle private_node_handle("~");
+    private_node_handle.getParam(INVERT_STEERING_PARAMETER, this->m_invert_steering);
 }
 
 /**
@@ -21,7 +25,12 @@ JoystickController::JoystickController()
  */
 void JoystickController::joystickCallback(const sensor_msgs::Joy::ConstPtr& joystick)
 {
-    double steering_angle = static_cast<double>(-joystick->axes[JOYSTICK_AXIS_STEERING]);
+    double steering_angle = static_cast<double>(joystick->axes[JOYSTICK_AXIS_STEERING]);
+    if (this->m_invert_steering)
+    {
+        steering_angle *= -1;
+    }
+
     double velocity = static_cast<double>(joystick->axes[JOYSTICK_AXIS_THROTTLE] - 1) * -0.5;
     velocity -= static_cast<double>(joystick->axes[JOYSTICK_AXIS_REVERSE] - 1) * -0.5;
 

--- a/ros_ws/src/teleoperation/src/joystick_controller.cpp
+++ b/ros_ws/src/teleoperation/src/joystick_controller.cpp
@@ -35,6 +35,13 @@ void JoystickController::joystickCallback(const sensor_msgs::Joy::ConstPtr& joys
     velocity -= static_cast<double>(joystick->axes[JOYSTICK_AXIS_REVERSE] - 1) * -0.5;
 
     this->publishDriveParameters(velocity, steering_angle);
+
+    // Detect if the button was pressed since the last reading
+    bool invert_toggle_button = joystick->buttons[JOYSTICK_BUTTON_TOGGLE_INVERT_STEERING] == 1;
+    if (invert_toggle_button && !this->m_toggle_invert_steering_state) {
+        this->m_invert_steering = !this->m_invert_steering;
+    }
+    this->m_toggle_invert_steering_state = invert_toggle_button;
 }
 
 /**


### PR DESCRIPTION
- Allows you to drive backwards with the left trigger
- Allows you to configure whether steering is inverted in the launch file, or at runtime using the X button on the gamepad

Before merging, this needs to be tested on our real hardware.