### PR TITLE
Added odometry topic for gazebo simulation

### DIFF
--- a/ros_ws/launch/gazebo_car-teleop.launch
+++ b/ros_ws/launch/gazebo_car-teleop.launch
@@ -1,4 +1,5 @@
 <launch>
     <include file="$(find racer_world)/launch/racer_gazebo.launch"/>
     <include file="$(find teleoperation)/launch/remote_control.launch"/>
+    <include file="$(find racer_sensors)/launch/racer_sensors.launch"/>
 </launch>

--- a/ros_ws/src/simulation/racer_sensors/CMakeLists.txt
+++ b/ros_ws/src/simulation/racer_sensors/CMakeLists.txt
@@ -38,6 +38,8 @@ include_directories(
 )
 
 # Declare car controller node executable
-add_executable(racer_sensors src/racer_odometry.cpp)
+add_executable(racer_sensors
+  src/racer_odometry.cpp
+  src/main_racer_odometry.cpp)
 target_link_libraries(racer_sensors ${catkin_LIBRARIES})
 add_dependencies(racer_sensors ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/ros_ws/src/simulation/racer_sensors/CMakeLists.txt
+++ b/ros_ws/src/simulation/racer_sensors/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(racer_sensors)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++1y)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  gazebo_msgs
+  geometry_msgs
+  nav_msgs
+  std_msgs
+)
+
+## Errors and Warnings
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
+# -Wpedantic cant be used because of ROS
+
+###################################
+## catkin specific configuration ##
+###################################
+
+## Declare things to be passed to dependent projects
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp gazebo_msgs geometry_msgs nav_msgs std_msgs
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+# Declare car controller node executable
+add_executable(racer_sensors src/racer_odometry.cpp)
+target_link_libraries(racer_sensors ${catkin_LIBRARIES})
+add_dependencies(racer_sensors ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/ros_ws/src/simulation/racer_sensors/include/racer_odometry.h
+++ b/ros_ws/src/simulation/racer_sensors/include/racer_odometry.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <boost/bind.hpp>
+
+#include <ros/ros.h>
+
+#include <gazebo_msgs/LinkStates.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Twist.h>
+#include <nav_msgs/Odometry.h>
+#include <std_msgs/Header.h>
+
+#define TOPIC_GAZEBO_ODOM "/gazebo/link_states"
+#define TOPIC_ODOM "/odom"
+
+#define BASE_LINK_NAME "racer::base_link"
+
+class RacerOdometry
+{
+    public:
+    RacerOdometry();
+
+    private:
+    ros::NodeHandle m_node_handle;
+
+    ros::Subscriber m_gazebo_subscriber;
+    ros::Publisher m_odom_publisher;
+
+    geometry_msgs::Pose m_last_received_pose;
+    geometry_msgs::Twist m_last_received_twist;
+    ros::Time m_last_received_stamp;
+
+    ros::Timer m_timer;
+
+    void robotPoseUpdate(const gazebo_msgs::LinkStates::ConstPtr& links);
+    void timerCallback(const ros::TimerEvent&);
+};

--- a/ros_ws/src/simulation/racer_sensors/include/racer_odometry.h
+++ b/ros_ws/src/simulation/racer_sensors/include/racer_odometry.h
@@ -10,28 +10,75 @@
 #include <nav_msgs/Odometry.h>
 #include <std_msgs/Header.h>
 
-#define TOPIC_GAZEBO_ODOM "/gazebo/link_states"
-#define TOPIC_ODOM "/odom"
+/**
+ * @brief Rostopic to which Gazebo publishes information about the models of the simulation.
+ */
+constexpr const char* TOPIC_GAZEBO_ODOM = "/gazebo/link_states";
 
-#define BASE_LINK_NAME "racer::base_link"
+/**
+ * @brief Rostopic to which the odometry data should be published to.
+ *
+ */
+constexpr const char* TOPIC_ODOM = "/odom";
+
+/**
+ * @brief Name of the link of the simulated car chassis.
+ *
+ */
+constexpr const char* BASE_LINK_NAME = "racer::base_link";
 
 class RacerOdometry
 {
     public:
+    /**
+     * @brief Construcs a new Racer Odometry object.
+     */
     RacerOdometry();
 
     private:
+    /**
+     * @brief ROS node handle, used for communication with the topics.
+     */
     ros::NodeHandle m_node_handle;
 
+    /**
+     * @brief Subscribes to the data published from Gazebo.
+     */
     ros::Subscriber m_gazebo_subscriber;
+
+    /**
+     * @brief Publishes the odometry data to the specified topic.
+     */
     ros::Publisher m_odom_publisher;
 
+    /**
+     * @brief Contains the last received pose from Gazebo.
+     */
     geometry_msgs::Pose m_last_received_pose;
+
+    /**
+     * @brief Contains the last received twist from Gazebo.
+     */
     geometry_msgs::Twist m_last_received_twist;
+
+    /**
+     * @brief Contains the time of the last received message from Gazebo.
+     */
     ros::Time m_last_received_stamp;
 
+    /**
+     * @brief Timer used for regulating the publish rate.
+     */
     ros::Timer m_timer;
 
+    /**
+     * @brief Updates the held variables upon receiving new data from Gazebo.
+     * @param links Contains information about all models in the Gazebo simulation.
+     */
     void robotPoseUpdate(const gazebo_msgs::LinkStates::ConstPtr& links);
+
+    /**
+     * @brief Publishes the last received odometry data at a rate defined by the timer.
+     */
     void timerCallback(const ros::TimerEvent&);
 };

--- a/ros_ws/src/simulation/racer_sensors/launch/racer_sensors.launch
+++ b/ros_ws/src/simulation/racer_sensors/launch/racer_sensors.launch
@@ -1,0 +1,10 @@
+<?xml version='1.0'?>
+
+<launch>
+    <node 
+        name = "racer_sensors"
+        pkg = "racer_sensors"
+        type = "racer_sensors"
+        output = "screen">
+    </node>
+</launch>

--- a/ros_ws/src/simulation/racer_sensors/package.xml
+++ b/ros_ws/src/simulation/racer_sensors/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>racer_sensors</name>
+  <version>0.0.0</version>
+  <description>The "racer_sensors" package provides sensor data from the simulated car.</description>
+
+  <!-- Maintainer -->
+  <maintainer email="f110@ls12.cs.uni-dortmund.de">PG F1/10</maintainer>
+
+  <!-- License -->
+  <license>MIT</license>
+  <license>GPLv3</license>
+
+  <!-- Dependencies -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>roscpp</depend>
+  <depend>gazebo_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>std_msgs</depend>
+
+</package>

--- a/ros_ws/src/simulation/racer_sensors/src/main_racer_odometry.cpp
+++ b/ros_ws/src/simulation/racer_sensors/src/main_racer_odometry.cpp
@@ -1,0 +1,9 @@
+#include "racer_odometry.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "racer_odometry");
+    RacerOdometry racerOdometry;
+    ros::spin();
+    return EXIT_SUCCESS;
+}

--- a/ros_ws/src/simulation/racer_sensors/src/racer_odometry.cpp
+++ b/ros_ws/src/simulation/racer_sensors/src/racer_odometry.cpp
@@ -16,7 +16,7 @@ RacerOdometry::RacerOdometry()
 
 void RacerOdometry::robotPoseUpdate(const gazebo_msgs::LinkStates::ConstPtr& links)
 {
-    for (uint i = 0; i < links->name.size(); i++)
+    for (unsigned int i = 0; i < links->name.size(); i++)
     {
         if (links->name.at(i) == BASE_LINK_NAME)
         {
@@ -31,18 +31,10 @@ void RacerOdometry::robotPoseUpdate(const gazebo_msgs::LinkStates::ConstPtr& lin
 void RacerOdometry::timerCallback(const ros::TimerEvent&)
 {
     nav_msgs::Odometry msg;
-    msg.header.stamp = m_last_received_stamp;
-    msg.header.frame_id = "map";
-    msg.child_frame_id = "odom";
-    msg.pose.pose = m_last_received_pose;
-    msg.twist.twist = m_last_received_twist;
+    {
+        msg.header.stamp = m_last_received_stamp;
+        msg.pose.pose = m_last_received_pose;
+        msg.twist.twist = m_last_received_twist;
+    }
     m_odom_publisher.publish(msg);
-}
-
-int main(int argc, char** argv)
-{
-    ros::init(argc, argv, "racer_odometry");
-    RacerOdometry racerOdometry;
-    ros::spin();
-    return EXIT_SUCCESS;
 }

--- a/ros_ws/src/simulation/racer_sensors/src/racer_odometry.cpp
+++ b/ros_ws/src/simulation/racer_sensors/src/racer_odometry.cpp
@@ -1,0 +1,48 @@
+#include <racer_odometry.h>
+
+RacerOdometry::RacerOdometry()
+{
+    m_gazebo_subscriber =
+        m_node_handle.subscribe<gazebo_msgs::LinkStates>(TOPIC_GAZEBO_ODOM, 1, &RacerOdometry::robotPoseUpdate, this);
+
+    m_odom_publisher = m_node_handle.advertise<nav_msgs::Odometry>(TOPIC_ODOM, 1);
+
+    m_last_received_pose = geometry_msgs::Pose();
+    m_last_received_twist = geometry_msgs::Twist();
+    m_last_received_stamp = ros::Time();
+
+    m_timer = m_node_handle.createTimer(ros::Duration(0.05), boost::bind(&RacerOdometry::timerCallback, this, _1));
+}
+
+void RacerOdometry::robotPoseUpdate(const gazebo_msgs::LinkStates::ConstPtr& links)
+{
+    for (uint i = 0; i < links->name.size(); i++)
+    {
+        if (links->name.at(i) == BASE_LINK_NAME)
+        {
+            m_last_received_pose = links->pose.at(i);
+            m_last_received_twist = links->twist.at(i);
+            m_last_received_stamp = ros::Time::now();
+            return;
+        }
+    }
+}
+
+void RacerOdometry::timerCallback(const ros::TimerEvent&)
+{
+    nav_msgs::Odometry msg;
+    msg.header.stamp = m_last_received_stamp;
+    msg.header.frame_id = "map";
+    msg.child_frame_id = "odom";
+    msg.pose.pose = m_last_received_pose;
+    msg.twist.twist = m_last_received_twist;
+    m_odom_publisher.publish(msg);
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "racer_odometry");
+    RacerOdometry racerOdometry;
+    ros::spin();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
implements #111 

The simulation now publishes a topic called "/odom" which contains all odometry data.
The implementation is based on [this python script from the racecar_gazebo project](https://github.com/mit-racecar/racecar-simulator/blob/master/racecar_gazebo/scripts/gazebo_odometry.py).