### PR TITLE
[RFC] More Warnings

### DIFF
--- a/ros_ws/src/car_control/CMakeLists.txt
+++ b/ros_ws/src/car_control/CMakeLists.txt
@@ -13,8 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## Errors and Warnings
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
-# -Wpedantic cant be used because of ROS
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked -Wpedantic ")
 
 ###################################
 ## catkin specific configuration ##

--- a/ros_ws/src/car_control/include/car_controller.h
+++ b/ros_ws/src/car_control/include/car_controller.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// Ignore some warnings from external headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 #include <ros/ros.h>
 
 #include <algorithm>
@@ -8,6 +12,9 @@
 #include <drive_msgs/drive_param.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/String.h>
+
+// Re-Enable the disabled warnings
+#pragma GCC diagnostic pop
 
 #define TOPIC_FOCBOX_SPEED "/commands/motor/speed"
 #define TOPIC_FOCBOX_ANGLE "/commands/servo/position"

--- a/ros_ws/src/drive_msgs/CMakeLists.txt
+++ b/ros_ws/src/drive_msgs/CMakeLists.txt
@@ -8,8 +8,8 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## Errors and Warnings
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
-# -Wpedantic cant be used because of ROS
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked -Wpedantic ")
+
 
 ################################################
 ## Declare ROS messages, services and actions ##

--- a/ros_ws/src/simulation/racer_control/CMakeLists.txt
+++ b/ros_ws/src/simulation/racer_control/CMakeLists.txt
@@ -14,8 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## Errors and Warnings
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
-# -Wpedantic cant be used because of ROS
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked -Wpedantic ")
 
 ###################################
 ## catkin specific configuration ##

--- a/ros_ws/src/simulation/racer_control/include/drive_param_converter.h
+++ b/ros_ws/src/simulation/racer_control/include/drive_param_converter.h
@@ -1,9 +1,16 @@
 #pragma once
 
+// Ignore some warnings from external headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 #include <ros/ros.h>
 
 #include <drive_msgs/drive_param.h>
 #include <std_msgs/Float64.h>
+
+// Re-Enable the disabled warnings
+#pragma GCC diagnostic pop
 
 /**
  * @brief Class to convert Drive Parameter Messages into single messages

--- a/ros_ws/src/teleoperation/CMakeLists.txt
+++ b/ros_ws/src/teleoperation/CMakeLists.txt
@@ -16,8 +16,7 @@ string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
 set(LIBS ${SDL2_LIBRARIES})
 
 ## Errors and Warnings
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
-# -Wpedantic cant be used because of ROS
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked -Wpedantic")
 
 ###################################
 ## catkin specific configuration ##

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -1,9 +1,17 @@
 #pragma once
 
+// Ignore some warnings from external headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 #include <ros/ros.h>
 
 #include <drive_msgs/drive_param.h>
 #include <sensor_msgs/Joy.h>
+
+// Re-Enable the disabled warnings
+#pragma GCC diagnostic pop
+
 
 #define JOYSTICK_AXIS_STEERING 0
 #define JOYSTICK_AXIS_THROTTLE 5

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// Ignore some warnings from external headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 #include <SDL2/SDL.h>
 #include <algorithm>
 #include <array>
@@ -8,6 +12,10 @@
 #include <ros/ros.h>
 #include <signal.h>
 #include <stdexcept>
+
+// Re-Enable the disabled warnings
+#pragma GCC diagnostic pop
+
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
 


### PR DESCRIPTION
Initial I didn't set -Wpedantic in the CXX_FLAGS because some external headers \*me looks at ROS\* triggers some warnings. My current RFC would be to disable -Wpedantic for external headers.

Known problems:
- It looks really ugly and the `#pragma GCC diagnostic` is prone for errors (e.g. forgotten pop)
- We have to ignore each warning separately (as GCC has nothing alike to clangs `-Weverything`)

Possible solutions:
- Code review
- Switch to clang and use `-Weverything`
