### PR TITLE
Keyboard controller improvements

### DIFF
--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -10,6 +10,7 @@
 #include <stdexcept>
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
+constexpr const char* TOPIC_DEAD_MANS_SWITCH = "set/dms";
 
 enum class Keycode : int
 {
@@ -25,12 +26,13 @@ enum class KeyIndex : int
     ACCELERATE = 0,
     DECELERATE = 2,
     STEER_LEFT = 1,
-    STEER_RIGHT = 3
+    STEER_RIGHT = 3,
+    DEAD_MANS_SWITCH = 4
 };
 
-constexpr int KEY_COUNT = 4;
+constexpr int KEY_COUNT = 5;
 
-constexpr std::array<Keycode, KEY_COUNT> KEY_CODES = { Keycode::W, Keycode::A, Keycode::S, Keycode::D };
+constexpr std::array<Keycode, KEY_COUNT> KEY_CODES = { Keycode::W, Keycode::A, Keycode::S, Keycode::D, Keycode::SPACE };
 
 constexpr double PARAMETER_UPDATE_FREQUENCY = 90;
 
@@ -62,6 +64,7 @@ class KeyboardController
     ros::NodeHandle m_node_handle;
 
     ros::Publisher m_drive_parameters_publisher;
+    ros::Publisher m_dead_mans_switch_publisher;
 
     SDL_Window* m_window;
 
@@ -77,6 +80,8 @@ class KeyboardController
     void updateDriveParameters(double delta_time);
 
     void publishDriveParameters();
+
+    void updateDeadMansSwitch();
 
     void createWindow();
     void timerCallback(const ros::TimerEvent& event);

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -41,13 +41,9 @@ constexpr double ACCELERATION = 3;
 // How fast the velocity changes when decelerating, in units per second
 constexpr double BRAKING = 8;
 
-// The steering angle is clamped so that its absolute value is not greater than this
-constexpr double MAX_STEERING = 0.7;
-// MAX_STEERING is multiplied by this when travelling at MAX_VELOCITY, by 1.0 when resting and by an interpolated value
-// otherwise
+// MAX_STEERING is multiplied by this when travelling at maximum velocity, by 1.0 when resting and by an interpolated
+// value otherwise
 constexpr double FAST_STEER_LIMIT = 0.6;
-// The velocity is clamped so that its absolute value is not greater than this
-constexpr double MAX_VELOCITY = 8;
 
 // When no steering key is pressed, the steering value will change towards 0 at this rate, in units per second
 constexpr double STEERING_GRAVITY = 2;

--- a/ros_ws/src/teleoperation/src/keyboard_controller.cpp
+++ b/ros_ws/src/teleoperation/src/keyboard_controller.cpp
@@ -102,6 +102,10 @@ void KeyboardController::timerCallback(const ros::TimerEvent& event)
  */
 void KeyboardController::updateDriveParameters(double delta_time)
 {
+// Disable warnings about equality comparisons for floats.
+// Equality comparisons are ok here because the variables are assigned the exact values that we compare them against.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
     double steer = this->m_key_pressed_state[(size_t)KeyIndex::STEER_LEFT]
         ? +1
         : (this->m_key_pressed_state[(size_t)KeyIndex::STEER_RIGHT] ? -1 : 0);
@@ -134,6 +138,7 @@ void KeyboardController::updateDriveParameters(double delta_time)
             this->m_velocity = 0;
         }
     }
+#pragma GCC diagnostic pop
 }
 
 void KeyboardController::publishDriveParameters()

--- a/ros_ws/src/teleoperation/src/keyboard_controller.cpp
+++ b/ros_ws/src/teleoperation/src/keyboard_controller.cpp
@@ -109,11 +109,11 @@ void KeyboardController::updateDriveParameters(double delta_time)
         ? +1
         : (this->m_key_pressed_state[(size_t)KeyIndex::DECELERATE] ? -1 : 0);
 
-    double steer_limit = map(abs(this->m_velocity), 0, MAX_VELOCITY, 1, FAST_STEER_LIMIT);
+    double steer_limit = map(abs(this->m_velocity), 0, 1, 1, FAST_STEER_LIMIT);
     double angle_update = steer * delta_time * STEERING_SPEED;
-    this->m_angle = clamp(this->m_angle + angle_update, -MAX_STEERING * steer_limit, +MAX_STEERING * steer_limit);
+    this->m_angle = clamp(this->m_angle + angle_update, -steer_limit, +steer_limit);
     double velocity_update = throttle * delta_time * (this->m_velocity * throttle > 0 ? ACCELERATION : BRAKING);
-    this->m_velocity = clamp(this->m_velocity + velocity_update, -MAX_VELOCITY, +MAX_VELOCITY);
+    this->m_velocity = clamp(this->m_velocity + velocity_update, -1, +1);
 
     if (steer == 0 && this->m_angle != 0)
     {


### PR DESCRIPTION
- Publish values between -1 and +1 for angle and velocity (see this [wiki article])(https://github.com/Autonomous-Racing-PG/ros.package/wiki/List-of-important-nodes-and-topics) and #122 
- Disable floating point comparison warnings
- Publish Dead Man's Switch messages