### PR TITLE
Implement Drive Parameter Multiplexer

### DIFF
--- a/ros_ws/src/autonomous/src/autonomous_control.cpp
+++ b/ros_ws/src/autonomous/src/autonomous_control.cpp
@@ -26,7 +26,7 @@ AutonomousControl::AutonomousControl()
 {
     m_pid_input =
         m_node_handle.subscribe<drive_msgs::pid_input>("/pid_input", 1, &AutonomousControl::pid_callback, this);
-    drive_param_publisher = m_node_handle.advertise<drive_msgs::drive_param>("/set/drive_param", 1);
+    drive_param_publisher = m_node_handle.advertise<drive_msgs::drive_param>("/set/drive_param_wallfollowing", 1);
 }
 
 /**

--- a/ros_ws/src/autonomous/src/autonomous_control.cpp
+++ b/ros_ws/src/autonomous/src/autonomous_control.cpp
@@ -26,7 +26,7 @@ AutonomousControl::AutonomousControl()
 {
     m_pid_input =
         m_node_handle.subscribe<drive_msgs::pid_input>("/pid_input", 1, &AutonomousControl::pid_callback, this);
-    drive_param_publisher = m_node_handle.advertise<drive_msgs::drive_param>("/set/drive_param_wallfollowing", 1);
+    drive_param_publisher = m_node_handle.advertise<drive_msgs::drive_param>("input/drive_param/wallfollowing", 1);
 }
 
 /**

--- a/ros_ws/src/car_control/CMakeLists.txt
+++ b/ros_ws/src/car_control/CMakeLists.txt
@@ -47,6 +47,11 @@ add_executable(dms_controller src/dms_controller.cpp)
 target_link_libraries(dms_controller ${catkin_LIBRARIES})
 add_dependencies(dms_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
+# Declare Drive Parameters Multiplexer node executable
+add_executable(drive_parameters_multiplexer src/drive_parameters_multiplexer.cpp src/drive_parameters_source.cpp)
+target_link_libraries(drive_parameters_multiplexer ${catkin_LIBRARIES})
+add_dependencies(drive_parameters_multiplexer ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
 
 #############
 ## Testing ##

--- a/ros_ws/src/car_control/include/dms_controller.h
+++ b/ros_ws/src/car_control/include/dms_controller.h
@@ -4,12 +4,13 @@
 
 #include <std_msgs/Int64.h>
 #include <std_msgs/String.h>
+#include <chrono>
 
 // How often the dead mans switch is checked. in Hz
 constexpr const int DMS_CHECK_RATE = 20;
 
-// How old the last dead mans switch check can be. in ms
-constexpr const int DMS_EXPIRATION = 100;
+// How old the last dead mans switch check can be, in seconds
+constexpr auto DMS_EXPIRATION = std::chrono::duration<double>(0.1);
 
 class DMSController
 {
@@ -18,7 +19,7 @@ class DMSController
     void checkDMS();
 
     private:
-    long m_last_dms_message_received = 0;
+    std::chrono::steady_clock::time_point m_last_dms_message_received;
     bool m_running = false;
     ros::NodeHandle m_node_handle;
     ros::Subscriber m_dms_subscriber;

--- a/ros_ws/src/car_control/include/dms_controller.h
+++ b/ros_ws/src/car_control/include/dms_controller.h
@@ -2,9 +2,9 @@
 
 #include <ros/ros.h>
 
+#include <chrono>
 #include <std_msgs/Int64.h>
 #include <std_msgs/String.h>
-#include <chrono>
 
 // How often the dead mans switch is checked. in Hz
 constexpr const int DMS_CHECK_RATE = 20;

--- a/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
+++ b/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
@@ -9,13 +9,13 @@
 #include <vector>
 
 /*
-*  This node subscribes to all publishers drive_param messages and selects one to forward to the car controller
+* This node subscribes to all publishers that send drive_param messages and selects one to forward to the car controller
 */
 class DriveParametersMultiplexer
 {
     public:
     /**
-     * @brief Construct a new DriveParametersMultiplexer object and initialize sources for all 
+     * @brief Construct a new DriveParametersMultiplexer object and initialize sources for all
      * publishers of drive parameters
      */
     DriveParametersMultiplexer();

--- a/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
+++ b/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ros/ros.h>
+
+#include "drive_parameters_source.h"
+#include "car_control.h"
+#include <drive_msgs/drive_param.h>
+#include <std_msgs/Float64.h>
+#include <vector>
+
+/*
+*  This node subscribes to all publishers drive_param messages and selects one to forward to the car controller
+*/
+class DriveParametersMultiplexer
+{
+    public:
+    DriveParametersMultiplexer();
+
+    private:
+    ros::NodeHandle m_node_handle;
+
+    std::vector<DriveParametersSource*> m_sources;
+
+    DriveParametersSource* m_last_updated_source;
+
+    ros::Publisher m_drive_parameters_publisher;
+
+    bool m_enabled;
+
+    bool validateSource(DriveParametersSource* source);
+    void onUpdate(DriveParametersSource* source, const drive_msgs::drive_param::ConstPtr& message);
+};

--- a/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
+++ b/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
@@ -14,6 +14,10 @@
 class DriveParametersMultiplexer
 {
     public:
+    /**
+     * @brief Construct a new DriveParametersMultiplexer object and initialize sources for all 
+     * publishers of drive parameters
+     */
     DriveParametersMultiplexer();
     ~DriveParametersMultiplexer();
 
@@ -24,6 +28,16 @@ class DriveParametersMultiplexer
     DriveParametersSource* m_last_updated_source;
     ros::Publisher m_drive_parameters_publisher;
 
+    /**
+     * @brief Determines wheter an updated source will be forwarded to the car controller,
+     * based on which source was previously forwarded, whether they are idle or outdated.
+     */
     bool validateSource(DriveParametersSource* source);
+
+    /**
+     * @brief This function should be called when a source has received a message.
+     * It determines if the message should be forwarded and if it should, it sends the message
+     * to the car controller.
+     */
     void onUpdate(DriveParametersSource* source, const drive_msgs::drive_param::ConstPtr& message);
 };

--- a/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
+++ b/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
@@ -19,12 +19,11 @@ class DriveParametersMultiplexer
      * publishers of drive parameters
      */
     DriveParametersMultiplexer();
-    ~DriveParametersMultiplexer();
 
     private:
     ros::NodeHandle m_node_handle;
 
-    std::vector<DriveParametersSource*> m_sources;
+    std::array<std::unique_ptr<DriveParametersSource>, 3> m_sources;
     DriveParametersSource* m_last_updated_source;
     ros::Publisher m_drive_parameters_publisher;
 

--- a/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
+++ b/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
@@ -15,17 +15,14 @@ class DriveParametersMultiplexer
 {
     public:
     DriveParametersMultiplexer();
+    ~DriveParametersMultiplexer();
 
     private:
     ros::NodeHandle m_node_handle;
 
     std::vector<DriveParametersSource*> m_sources;
-
     DriveParametersSource* m_last_updated_source;
-
     ros::Publisher m_drive_parameters_publisher;
-
-    bool m_enabled;
 
     bool validateSource(DriveParametersSource* source);
     void onUpdate(DriveParametersSource* source, const drive_msgs::drive_param::ConstPtr& message);

--- a/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
+++ b/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
@@ -2,8 +2,8 @@
 
 #include <ros/ros.h>
 
-#include "drive_parameters_source.h"
 #include "car_control.h"
+#include "drive_parameters_source.h"
 #include <drive_msgs/drive_param.h>
 #include <std_msgs/Float64.h>
 #include <vector>

--- a/ros_ws/src/car_control/include/drive_parameters_source.h
+++ b/ros_ws/src/car_control/include/drive_parameters_source.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ros/ros.h>
+
+#include <drive_msgs/drive_param.h>
+#include <std_msgs/Float64.h>
+#include <functional>
+
+/*
+*  This node subscribes to all publishers drive_param messages and selects one to forward to the car controller
+*/
+class DriveParametersSource
+{
+    public:
+    DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> update_callback, int priority, double timeout);
+    
+    bool isOutdated();
+    bool isIdle();
+    int getPriority();
+
+    private:
+    ros::Subscriber m_drive_parameters_subscriber;
+
+    int m_priority;
+    long int m_timeout;
+    bool m_idle;
+    long int m_last_update;
+
+    std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> m_updateCallback;
+
+    void driveParametersCallback(const drive_msgs::drive_param::ConstPtr& parameters);
+};

--- a/ros_ws/src/car_control/include/drive_parameters_source.h
+++ b/ros_ws/src/car_control/include/drive_parameters_source.h
@@ -11,7 +11,7 @@ typedef std::function<void(DriveParametersSource*, const drive_msgs::drive_param
     DriveParameterCallbackFunction;
 
 /*
-*  This node subscribes to all publishers drive_param messages and selects one to forward to the car controller
+*  A class that listens on a topic that publishes drive parameters and stores information about that source
 */
 class DriveParametersSource
 {
@@ -19,8 +19,17 @@ class DriveParametersSource
     DriveParametersSource(ros::NodeHandle* node_handle, const char* topic,
                           DriveParameterCallbackFunction update_callback, int priority, double timeout);
 
+    /**
+     * @brief Returns true if no update was received for a certain time, determined by the timeout variable.
+     */
     bool isOutdated();
+
+    /**
+     * @brief Returns true if the last update contained values close to 0 for both steering and throttle.
+     * If no update was received yet, this returns true.
+     */
     bool isIdle();
+    
     int getPriority();
 
     private:

--- a/ros_ws/src/car_control/include/drive_parameters_source.h
+++ b/ros_ws/src/car_control/include/drive_parameters_source.h
@@ -2,13 +2,14 @@
 
 #include <ros/ros.h>
 
+#include <chrono>
 #include <drive_msgs/drive_param.h>
 #include <functional>
 #include <std_msgs/Float64.h>
-#include <chrono>
 
 class DriveParametersSource;
-using DriveParameterCallbackFunction = std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)>;
+using DriveParameterCallbackFunction =
+    std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)>;
 
 constexpr double IDLE_RANGE = 0.01;
 

--- a/ros_ws/src/car_control/include/drive_parameters_source.h
+++ b/ros_ws/src/car_control/include/drive_parameters_source.h
@@ -3,11 +3,12 @@
 #include <ros/ros.h>
 
 #include <drive_msgs/drive_param.h>
-#include <std_msgs/Float64.h>
 #include <functional>
+#include <std_msgs/Float64.h>
 
 class DriveParametersSource;
-typedef std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> DriveParameterCallbackFunction;
+typedef std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)>
+    DriveParameterCallbackFunction;
 
 /*
 *  This node subscribes to all publishers drive_param messages and selects one to forward to the car controller
@@ -15,8 +16,9 @@ typedef std::function<void(DriveParametersSource*, const drive_msgs::drive_param
 class DriveParametersSource
 {
     public:
-    DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, DriveParameterCallbackFunction update_callback, int priority, double timeout);
-    
+    DriveParametersSource(ros::NodeHandle* node_handle, const char* topic,
+                          DriveParameterCallbackFunction update_callback, int priority, double timeout);
+
     bool isOutdated();
     bool isIdle();
     int getPriority();

--- a/ros_ws/src/car_control/include/drive_parameters_source.h
+++ b/ros_ws/src/car_control/include/drive_parameters_source.h
@@ -10,12 +10,24 @@ class DriveParametersSource;
 typedef std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)>
     DriveParameterCallbackFunction;
 
+constexpr double IDLE_RANGE = 0.01;
+
 /*
 *  A class that listens on a topic that publishes drive parameters and stores information about that source
 */
 class DriveParametersSource
 {
     public:
+    /**
+     * @brief Construct a new DriveParametersSource object,
+     * subscribes to the topic and stores the parameters into local variables.
+     *
+     * @param node_handle A node handle is needed to create a topic subscriber
+     * @param topic The name of the drive_param topic to subscribe to
+     * @param update_callback Callback function that will be called whenever a message was received
+     * @param priority Priority of the source. Sources with higher priority will be preferred.
+     * @param timeout Messages will be deferred when they are older than this, in seconds.
+     */
     DriveParametersSource(ros::NodeHandle* node_handle, const char* topic,
                           DriveParameterCallbackFunction update_callback, int priority, double timeout);
 
@@ -29,7 +41,7 @@ class DriveParametersSource
      * If no update was received yet, this returns true.
      */
     bool isIdle();
-    
+
     int getPriority();
 
     private:

--- a/ros_ws/src/car_control/include/drive_parameters_source.h
+++ b/ros_ws/src/car_control/include/drive_parameters_source.h
@@ -6,13 +6,16 @@
 #include <std_msgs/Float64.h>
 #include <functional>
 
+class DriveParametersSource;
+typedef std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> DriveParameterCallbackFunction;
+
 /*
 *  This node subscribes to all publishers drive_param messages and selects one to forward to the car controller
 */
 class DriveParametersSource
 {
     public:
-    DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> update_callback, int priority, double timeout);
+    DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, DriveParameterCallbackFunction update_callback, int priority, double timeout);
     
     bool isOutdated();
     bool isIdle();
@@ -26,7 +29,7 @@ class DriveParametersSource
     bool m_idle;
     long int m_last_update;
 
-    std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> m_updateCallback;
+    DriveParameterCallbackFunction m_updateCallback;
 
     void driveParametersCallback(const drive_msgs::drive_param::ConstPtr& parameters);
 };

--- a/ros_ws/src/car_control/launch/car_control.launch
+++ b/ros_ws/src/car_control/launch/car_control.launch
@@ -21,5 +21,15 @@ Launches all necessary nodes that listen for drive_parameters and translate them
       name="dms_controller"
       output="screen" >
     </node>
+
+
+    <!-- Drive Parameters Multiplexer node -->
+    <node
+      respawn="true"
+      pkg="car_control"
+      type="drive_parameters_multiplexer"
+      name="drive_parameters_multiplexer"
+      output="screen" >
+    </node>
 	
 </launch>

--- a/ros_ws/src/car_control/src/dms_controller.cpp
+++ b/ros_ws/src/car_control/src/dms_controller.cpp
@@ -15,15 +15,13 @@ DMSController::DMSController()
 
 void DMSController::checkDMS()
 {
-    struct timeval time_struct;
-    gettimeofday(&time_struct, NULL);
-    long int timestamp = time_struct.tv_sec * 1000 + time_struct.tv_usec / 1000;
+    auto current_time = std::chrono::steady_clock::now();
 
     if (m_running)
     {
         // switch is triggered
 
-        if (m_last_dms_message_received + DMS_EXPIRATION < timestamp)
+        if (m_last_dms_message_received + DMS_EXPIRATION < current_time)
         {
             // switch is not triggered anymode
             m_running = false;
@@ -36,7 +34,7 @@ void DMSController::checkDMS()
     {
         // switch is not triggered
 
-        if (m_last_dms_message_received + DMS_EXPIRATION >= timestamp)
+        if (m_last_dms_message_received + DMS_EXPIRATION >= current_time)
         {
 
             // switch is is triggered again
@@ -50,7 +48,8 @@ void DMSController::checkDMS()
 
 void DMSController::dmsCallback(const std_msgs::Int64::ConstPtr& dms_message)
 {
-    this->m_last_dms_message_received = dms_message->data;
+    std::chrono::milliseconds time_since_epoch(dms_message->data);
+    this->m_last_dms_message_received = std::chrono::time_point<std::chrono::steady_clock>(time_since_epoch);
 }
 
 int main(int argc, char** argv)

--- a/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
@@ -6,26 +6,19 @@ DriveParametersMultiplexer::DriveParametersMultiplexer()
     this->m_last_updated_source = NULL;
     auto callback =
         std::bind(&DriveParametersMultiplexer::onUpdate, this, std::placeholders::_1, std::placeholders::_2);
-    this->m_sources.push_back(
-        new DriveParametersSource(&this->m_node_handle, "input/drive_param/keyboard", callback, 1, 0.1));
-    this->m_sources.push_back(
-        new DriveParametersSource(&this->m_node_handle, "input/drive_param/joystick", callback, 1, 0.1));
-    this->m_sources.push_back(
-        new DriveParametersSource(&this->m_node_handle, "input/drive_param/wallfollowing", callback, 0, 0.1));
-}
 
-DriveParametersMultiplexer::~DriveParametersMultiplexer()
-{
-    for (auto source : this->m_sources)
-    {
-        delete source;
-    }
+    this->m_sources = {
+        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/keyboard", callback, 1, 0.1)),
+        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/joystick", callback, 1, 0.1)),
+        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/wallfollowing", callback, 0, 0.1)),
+    };
 }
 
 // clang-format off
 bool DriveParametersMultiplexer::validateSource(DriveParametersSource* source)
 {
-    return this->m_last_updated_source == NULL
+    ROS_ASSERT_MSG(source != nullptr, "Parameter 'source' must not be null.");
+    return this->m_last_updated_source == nullptr
         || this->m_last_updated_source == source
         || this->m_last_updated_source->isOutdated()
         || (!source->isIdle() && this->m_last_updated_source->isIdle())
@@ -36,6 +29,7 @@ bool DriveParametersMultiplexer::validateSource(DriveParametersSource* source)
 void DriveParametersMultiplexer::onUpdate(DriveParametersSource* source,
                                           const drive_msgs::drive_param::ConstPtr& message)
 {
+    ROS_ASSERT_MSG(source != nullptr, "Parameter 'source' must not be null.");
     if (!this->validateSource(source))
     {
         return;

--- a/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
@@ -4,30 +4,40 @@ DriveParametersMultiplexer::DriveParametersMultiplexer()
 {
     this->m_drive_parameters_publisher = this->m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAM, 1);
     this->m_last_updated_source = NULL;
-    auto callback = std::bind(&DriveParametersMultiplexer::onUpdate, this, std::placeholders::_1, std::placeholders::_2);
-    this->m_sources.push_back(new DriveParametersSource(&this->m_node_handle, "/set/drive_param_keyboard", callback, 1, 0.1));
-    this->m_sources.push_back(new DriveParametersSource(&this->m_node_handle, "/set/drive_param_joystick", callback, 1, 0.1));
-    this->m_sources.push_back(new DriveParametersSource(&this->m_node_handle, "/set/drive_param_wallfollowing", callback, 0, 0.1));
+    auto callback =
+        std::bind(&DriveParametersMultiplexer::onUpdate, this, std::placeholders::_1, std::placeholders::_2);
+    this->m_sources.push_back(
+        new DriveParametersSource(&this->m_node_handle, "/set/drive_param_keyboard", callback, 1, 0.1));
+    this->m_sources.push_back(
+        new DriveParametersSource(&this->m_node_handle, "/set/drive_param_joystick", callback, 1, 0.1));
+    this->m_sources.push_back(
+        new DriveParametersSource(&this->m_node_handle, "/set/drive_param_wallfollowing", callback, 0, 0.1));
 }
 
 DriveParametersMultiplexer::~DriveParametersMultiplexer()
 {
-    for (auto source : this->m_sources) {
+    for (auto source : this->m_sources)
+    {
         delete source;
     }
 }
 
-
-bool DriveParametersMultiplexer::validateSource(DriveParametersSource* source) {
+// clang-format off
+bool DriveParametersMultiplexer::validateSource(DriveParametersSource* source)
+{
     return this->m_last_updated_source == NULL
         || this->m_last_updated_source == source
         || this->m_last_updated_source->isOutdated()
         || (!source->isIdle() && this->m_last_updated_source->isIdle())
         || (!source->isIdle() && this->m_last_updated_source->getPriority() < source->getPriority());
 }
+// clang-format on
 
-void DriveParametersMultiplexer::onUpdate(DriveParametersSource* source, const drive_msgs::drive_param::ConstPtr& message) {
-    if (!this->validateSource(source)) {
+void DriveParametersMultiplexer::onUpdate(DriveParametersSource* source,
+                                          const drive_msgs::drive_param::ConstPtr& message)
+{
+    if (!this->validateSource(source))
+    {
         return;
     }
     this->m_drive_parameters_publisher.publish(message);

--- a/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
@@ -1,0 +1,35 @@
+#include "drive_parameters_multiplexer.h"
+
+DriveParametersMultiplexer::DriveParametersMultiplexer()
+{
+    this->m_drive_parameters_publisher = this->m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAM, 1);
+    this->m_last_updated_source = NULL;
+    auto callback = std::bind(&DriveParametersMultiplexer::onUpdate, this, std::placeholders::_1, std::placeholders::_2);
+    this->m_sources.push_back(new DriveParametersSource(&this->m_node_handle, "/set/drive_param_keyboard", callback, 1, 0.1));
+    this->m_sources.push_back(new DriveParametersSource(&this->m_node_handle, "/set/drive_param_joystick", callback, 1, 0.1));
+    this->m_sources.push_back(new DriveParametersSource(&this->m_node_handle, "/set/drive_param_wallfollowing", callback, 0, 0.1));
+}
+
+bool DriveParametersMultiplexer::validateSource(DriveParametersSource* source) {
+    return this->m_last_updated_source == NULL
+        || this->m_last_updated_source == source
+        || this->m_last_updated_source->isOutdated()
+        || (this->m_last_updated_source->isIdle() && !source->isIdle())
+        || (!source->isIdle() && this->m_last_updated_source->getPriority() < source->getPriority());
+}
+
+void DriveParametersMultiplexer::onUpdate(DriveParametersSource* source, const drive_msgs::drive_param::ConstPtr& message) {
+    if (!this->validateSource(source)) {
+        return;
+    }
+    this->m_drive_parameters_publisher.publish(message);
+    this->m_last_updated_source = source;
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "drive_parameters_multiplexer");
+    DriveParametersMultiplexer multiplexer;
+    ros::spin();
+    return EXIT_SUCCESS;
+}

--- a/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
@@ -8,9 +8,12 @@ DriveParametersMultiplexer::DriveParametersMultiplexer()
         std::bind(&DriveParametersMultiplexer::onUpdate, this, std::placeholders::_1, std::placeholders::_2);
 
     this->m_sources = {
-        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/keyboard", callback, 1, 0.1)),
-        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/joystick", callback, 1, 0.1)),
-        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/wallfollowing", callback, 0, 0.1)),
+        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/keyboard", callback,
+                                                          1, 0.1)),
+        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/joystick", callback,
+                                                          1, 0.1)),
+        std::move(std::make_unique<DriveParametersSource>(&this->m_node_handle, "input/drive_param/wallfollowing",
+                                                          callback, 0, 0.1)),
     };
 }
 

--- a/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
@@ -10,11 +10,19 @@ DriveParametersMultiplexer::DriveParametersMultiplexer()
     this->m_sources.push_back(new DriveParametersSource(&this->m_node_handle, "/set/drive_param_wallfollowing", callback, 0, 0.1));
 }
 
+DriveParametersMultiplexer::~DriveParametersMultiplexer()
+{
+    for (auto source : this->m_sources) {
+        delete source;
+    }
+}
+
+
 bool DriveParametersMultiplexer::validateSource(DriveParametersSource* source) {
     return this->m_last_updated_source == NULL
         || this->m_last_updated_source == source
         || this->m_last_updated_source->isOutdated()
-        || (this->m_last_updated_source->isIdle() && !source->isIdle())
+        || (!source->isIdle() && this->m_last_updated_source->isIdle())
         || (!source->isIdle() && this->m_last_updated_source->getPriority() < source->getPriority());
 }
 

--- a/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_multiplexer.cpp
@@ -7,11 +7,11 @@ DriveParametersMultiplexer::DriveParametersMultiplexer()
     auto callback =
         std::bind(&DriveParametersMultiplexer::onUpdate, this, std::placeholders::_1, std::placeholders::_2);
     this->m_sources.push_back(
-        new DriveParametersSource(&this->m_node_handle, "/set/drive_param_keyboard", callback, 1, 0.1));
+        new DriveParametersSource(&this->m_node_handle, "input/drive_param/keyboard", callback, 1, 0.1));
     this->m_sources.push_back(
-        new DriveParametersSource(&this->m_node_handle, "/set/drive_param_joystick", callback, 1, 0.1));
+        new DriveParametersSource(&this->m_node_handle, "input/drive_param/joystick", callback, 1, 0.1));
     this->m_sources.push_back(
-        new DriveParametersSource(&this->m_node_handle, "/set/drive_param_wallfollowing", callback, 0, 0.1));
+        new DriveParametersSource(&this->m_node_handle, "input/drive_param/wallfollowing", callback, 0, 0.1));
 }
 
 DriveParametersMultiplexer::~DriveParametersMultiplexer()

--- a/ros_ws/src/car_control/src/drive_parameters_source.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_source.cpp
@@ -1,0 +1,39 @@
+#include "drive_parameters_source.h"
+#include <math.h>
+
+long int getTime() {
+    struct timeval time_struct;
+    gettimeofday(&time_struct, NULL);
+    return time_struct.tv_sec * 1000 + time_struct.tv_usec / 1000;
+}
+
+DriveParametersSource::DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> update_callback, int priority, double timeout)
+{
+    this->m_drive_parameters_subscriber = node_handle->subscribe<drive_msgs::drive_param>(topic, 1, &DriveParametersSource::driveParametersCallback, this);
+    this->m_priority = priority;
+    this->m_timeout = (long int)(timeout * 1000.0);
+    this->m_last_update = 0;
+    this->m_idle = true;
+    this->m_updateCallback = update_callback;
+}
+
+void DriveParametersSource::driveParametersCallback(const drive_msgs::drive_param::ConstPtr& message) {
+    this->m_last_update = getTime();
+    this->m_idle = fabs(message->velocity) < 0.01 && fabs(message->angle) < 0.01;
+    this->m_updateCallback(this, message);
+}
+
+bool DriveParametersSource::isOutdated() {
+    if (this->m_last_update == 0) {
+        return true;
+    }
+    return this->m_last_update + this->m_timeout < getTime();
+}
+
+bool DriveParametersSource::isIdle() {
+    return this->m_idle;
+}
+
+int DriveParametersSource::getPriority() {
+    return this->m_priority;
+}

--- a/ros_ws/src/car_control/src/drive_parameters_source.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_source.cpp
@@ -1,15 +1,20 @@
 #include "drive_parameters_source.h"
 #include <math.h>
 
-long int getTime() {
+long int getTime()
+{
     struct timeval time_struct;
     gettimeofday(&time_struct, NULL);
     return time_struct.tv_sec * 1000 + time_struct.tv_usec / 1000;
 }
 
-DriveParametersSource::DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, DriveParameterCallbackFunction update_callback, int priority, double timeout)
+DriveParametersSource::DriveParametersSource(ros::NodeHandle* node_handle, const char* topic,
+                                             DriveParameterCallbackFunction update_callback, int priority,
+                                             double timeout)
 {
-    this->m_drive_parameters_subscriber = node_handle->subscribe<drive_msgs::drive_param>(topic, 1, &DriveParametersSource::driveParametersCallback, this);
+    this->m_drive_parameters_subscriber =
+        node_handle->subscribe<drive_msgs::drive_param>(topic, 1, &DriveParametersSource::driveParametersCallback,
+                                                        this);
     this->m_priority = priority;
     this->m_timeout = (long int)(timeout * 1000.0);
     this->m_last_update = 0;
@@ -17,23 +22,28 @@ DriveParametersSource::DriveParametersSource(ros::NodeHandle* node_handle, const
     this->m_updateCallback = update_callback;
 }
 
-void DriveParametersSource::driveParametersCallback(const drive_msgs::drive_param::ConstPtr& message) {
+void DriveParametersSource::driveParametersCallback(const drive_msgs::drive_param::ConstPtr& message)
+{
     this->m_last_update = getTime();
     this->m_idle = fabs(message->velocity) < 0.01 && fabs(message->angle) < 0.01;
     this->m_updateCallback(this, message);
 }
 
-bool DriveParametersSource::isOutdated() {
-    if (this->m_last_update == 0) {
+bool DriveParametersSource::isOutdated()
+{
+    if (this->m_last_update == 0)
+    {
         return true;
     }
     return this->m_last_update + this->m_timeout < getTime();
 }
 
-bool DriveParametersSource::isIdle() {
+bool DriveParametersSource::isIdle()
+{
     return this->m_idle;
 }
 
-int DriveParametersSource::getPriority() {
+int DriveParametersSource::getPriority()
+{
     return this->m_priority;
 }

--- a/ros_ws/src/car_control/src/drive_parameters_source.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_source.cpp
@@ -25,7 +25,7 @@ DriveParametersSource::DriveParametersSource(ros::NodeHandle* node_handle, const
 void DriveParametersSource::driveParametersCallback(const drive_msgs::drive_param::ConstPtr& message)
 {
     this->m_last_update = getTime();
-    this->m_idle = fabs(message->velocity) < 0.01 && fabs(message->angle) < 0.01;
+    this->m_idle = fabs(message->velocity) < IDLE_RANGE && fabs(message->angle) < IDLE_RANGE;
     this->m_updateCallback(this, message);
 }
 

--- a/ros_ws/src/car_control/src/drive_parameters_source.cpp
+++ b/ros_ws/src/car_control/src/drive_parameters_source.cpp
@@ -7,7 +7,7 @@ long int getTime() {
     return time_struct.tv_sec * 1000 + time_struct.tv_usec / 1000;
 }
 
-DriveParametersSource::DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, std::function<void(DriveParametersSource*, const drive_msgs::drive_param::ConstPtr&)> update_callback, int priority, double timeout)
+DriveParametersSource::DriveParametersSource(ros::NodeHandle* node_handle, const char* topic, DriveParameterCallbackFunction update_callback, int priority, double timeout)
 {
     this->m_drive_parameters_subscriber = node_handle->subscribe<drive_msgs::drive_param>(topic, 1, &DriveParametersSource::driveParametersCallback, this);
     this->m_priority = priority;

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -12,7 +12,7 @@ constexpr int JOYSTICK_BUTTON_DEADMANSSWITCH = 0;
 constexpr int JOYSTICK_BUTTON_TOGGLE_INVERT_STEERING = 2;
 
 constexpr const char* INVERT_STEERING_PARAMETER = "invert_steering";
-constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
+constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param_joystick";
 constexpr const char* TOPIC_DMS = "/set/dms";
 
 class JoystickController

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -12,7 +12,7 @@ constexpr int JOYSTICK_BUTTON_DEADMANSSWITCH = 0;
 constexpr int JOYSTICK_BUTTON_TOGGLE_INVERT_STEERING = 2;
 
 constexpr const char* INVERT_STEERING_PARAMETER = "invert_steering";
-constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param_joystick";
+constexpr const char* TOPIC_DRIVE_PARAMETERS = "input/drive_param/joystick";
 constexpr const char* TOPIC_DMS = "/set/dms";
 
 class JoystickController

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -2,9 +2,9 @@
 
 #include <ros/ros.h>
 
+#include <chrono>
 #include <drive_msgs/drive_param.h>
 #include <sensor_msgs/Joy.h>
-#include <chrono>
 
 constexpr int JOYSTICK_AXIS_STEERING = 0;
 constexpr int JOYSTICK_AXIS_THROTTLE = 5;

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -4,6 +4,7 @@
 
 #include <drive_msgs/drive_param.h>
 #include <sensor_msgs/Joy.h>
+#include <chrono>
 
 constexpr int JOYSTICK_AXIS_STEERING = 0;
 constexpr int JOYSTICK_AXIS_THROTTLE = 5;

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -3,13 +3,13 @@
 #include <SDL2/SDL.h>
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <drive_msgs/drive_param.h>
 #include <ros/package.h>
 #include <ros/ros.h>
 #include <signal.h>
 #include <std_msgs/String.h>
 #include <stdexcept>
-#include <chrono>
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "input/drive_param/keyboard";
 constexpr const char* TOPIC_DEAD_MANS_SWITCH = "/set/dms";

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -10,8 +10,9 @@
 #include <std_msgs/String.h>
 #include <stdexcept>
 
-constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param_keyboard";
-constexpr const char* TOPIC_DEAD_MANS_SWITCH = "set/dms";
+constexpr const char* TOPIC_DRIVE_PARAMETERS = "input/drive_param/keyboard";
+constexpr const char* TOPIC_DEAD_MANS_SWITCH = "/set/dms";
+constexpr const char* TOPIC_COMMAND = "/command";
 
 constexpr const char* COMMAND_STOP = "stop";
 constexpr const char* COMMAND_GO = "go";

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -10,9 +10,8 @@
 #include <std_msgs/String.h>
 #include <stdexcept>
 
-constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param";
-constexpr const char* TOPIC_DEAD_MANS_SWITCH = "/set/dms";
-constexpr const char* TOPIC_COMMAND = "/command";
+constexpr const char* TOPIC_DRIVE_PARAMETERS = "/set/drive_param_keyboard";
+constexpr const char* TOPIC_DEAD_MANS_SWITCH = "set/dms";
 
 constexpr const char* COMMAND_STOP = "stop";
 constexpr const char* COMMAND_GO = "go";

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -9,6 +9,7 @@
 #include <signal.h>
 #include <std_msgs/String.h>
 #include <stdexcept>
+#include <chrono>
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "input/drive_param/keyboard";
 constexpr const char* TOPIC_DEAD_MANS_SWITCH = "/set/dms";

--- a/ros_ws/src/teleoperation/src/joystick_controller.cpp
+++ b/ros_ws/src/teleoperation/src/joystick_controller.cpp
@@ -33,7 +33,7 @@ void JoystickController::joystickCallback(const sensor_msgs::Joy::ConstPtr& joys
     {
         auto now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now());
         auto time_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
-        
+
         std_msgs::Int64 dead_mans_switch_message;
         dead_mans_switch_message.data = time_since_epoch.count();
 

--- a/ros_ws/src/teleoperation/src/joystick_controller.cpp
+++ b/ros_ws/src/teleoperation/src/joystick_controller.cpp
@@ -31,13 +31,13 @@ void JoystickController::joystickCallback(const sensor_msgs::Joy::ConstPtr& joys
     int dms_button_value = joystick->buttons[JOYSTICK_BUTTON_DEADMANSSWITCH];
     if (dms_button_value == 1) // 1 if button is pressed
     {
-        struct timeval time_struct;
-        gettimeofday(&time_struct, NULL);
-        long int timestamp = time_struct.tv_sec * 1000 + time_struct.tv_usec / 1000;
-        std_msgs::Int64 dms_message;
-        dms_message.data = timestamp;
+        auto now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now());
+        auto time_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+        
+        std_msgs::Int64 dead_mans_switch_message;
+        dead_mans_switch_message.data = time_since_epoch.count();
 
-        this->m_dms_publisher.publish(dms_message);
+        this->m_dms_publisher.publish(dead_mans_switch_message);
     }
 
     // compute and publish angle and velocity

--- a/ros_ws/src/teleoperation/src/keyboard_controller.cpp
+++ b/ros_ws/src/teleoperation/src/keyboard_controller.cpp
@@ -122,7 +122,7 @@ void KeyboardController::updateDeadMansSwitch()
     {
         auto now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now());
         auto time_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
-        
+
         std_msgs::Int64 dead_mans_switch_message;
         dead_mans_switch_message.data = time_since_epoch.count();
 

--- a/ros_ws/src/teleoperation/src/keyboard_controller.cpp
+++ b/ros_ws/src/teleoperation/src/keyboard_controller.cpp
@@ -120,11 +120,11 @@ void KeyboardController::updateDeadMansSwitch()
 {
     if (this->m_key_pressed_state[(size_t)KeyIndex::DEAD_MANS_SWITCH])
     {
-        struct timeval time_struct;
-        gettimeofday(&time_struct, NULL);
-        long int timestamp = time_struct.tv_sec * 1000 + time_struct.tv_usec / 1000;
+        auto now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now());
+        auto time_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+        
         std_msgs::Int64 dead_mans_switch_message;
-        dead_mans_switch_message.data = timestamp;
+        dead_mans_switch_message.data = time_since_epoch.count();
 
         this->m_dead_mans_switch_publisher.publish(dead_mans_switch_message);
     }


### PR DESCRIPTION
Every node that published to `/set/drive_params` now publishes to a separate topic.
A new node `DriveParameterMultiplexer` listens to them and forwards the commands from one to the `/set/drive_params` topic.
When multiple controllers are publishing at the same time, such as joystick, keyboard and autonomous, they now behave as expected.