### PR TITLE
Remove sdl2 catkin dependency

### DIFF
--- a/ros_ws/src/teleoperation/CMakeLists.txt
+++ b/ros_ws/src/teleoperation/CMakeLists.txt
@@ -27,7 +27,6 @@ set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS drive_msgs roscpp std_msgs
-  DEPENDS ${LIBS}
 )
 
 


### PR DESCRIPTION
The teleoperation package has a sdl2 catkin dependency which causes some cmake warnings. It compiles fine without that line. Is it really necessary?