### PR TITLE
Fix roslaunch arg support

### DIFF
--- a/ros_ws/launch/car-teleop.launch
+++ b/ros_ws/launch/car-teleop.launch
@@ -1,5 +1,13 @@
 <launch>
+
+    <arg name="joystick_type" default="xbox360"/>
+
     <include file="$(find car_control)/launch/car_control.launch"/>
-    <include file="$(find teleoperation)/launch/remote_control.launch"/>
+
+    <include file="$(find teleoperation)/launch/remote_control.launch">
+        <arg name="joystick_type" value="$(arg joystick_type)"/>
+    </include>
+
     <include file="$(find vesc_driver)/launch/vesc_driver_node.launch"/>
+
 </launch>

--- a/ros_ws/launch/gazebo_car-autonomous.launch
+++ b/ros_ws/launch/gazebo_car-autonomous.launch
@@ -1,4 +1,23 @@
 <launch>
-    <include file="$(find racer_world)/launch/racer_gazebo_rviz.launch"/>
+
+    <arg name="world" default="racetrack_decorated"/>
+    <arg name="paused" default="false"/>
+    <arg name="use_sim_time" default="true"/>
+    <arg name="gui" default="true"/>
+    <arg name="headless" default="false"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="true"/>
+
+    <include file="$(find racer_world)/launch/racer_gazebo_rviz.launch">
+        <arg name="world" value="$(arg world)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="use_sim_time" value="$(arg use_sim_time)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="headless" value="$(arg headless)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+    </include>
+
     <include file="$(find autonomous)/launch/autonomous_driving.launch"/>
+
 </launch>

--- a/ros_ws/launch/gazebo_car-teleop.launch
+++ b/ros_ws/launch/gazebo_car-teleop.launch
@@ -1,6 +1,30 @@
 <launch>
-    <include file="$(find racer_world)/launch/racer_gazebo_rviz.launch"/>
+
+    <arg name="world" default="racetrack_decorated"/>
+    <arg name="paused" default="false"/>
+    <arg name="use_sim_time" default="true"/>
+    <arg name="gui" default="true"/>
+    <arg name="headless" default="false"/>
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="true"/>
+    <arg name="joystick_type" default="xbox360"/>
+
+    <include file="$(find racer_world)/launch/racer_gazebo_rviz.launch">
+        <arg name="world" value="$(arg world)"/>
+        <arg name="paused" value="$(arg paused)"/>
+        <arg name="use_sim_time" value="$(arg use_sim_time)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="headless" value="$(arg headless)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+    </include>
+
     <include file="$(find vesc_sim)/launch/vesc_sim.launch"/>
+
     <include file="$(find car_control)/launch/car_control.launch"/>
-    <include file="$(find teleoperation)/launch/remote_control.launch"/>
+
+    <include file="$(find teleoperation)/launch/remote_control.launch">
+        <arg name="joystick_type" value="$(arg joystick_type)"/>
+    </include>
+
 </launch>

--- a/ros_ws/src/simulation/racer_world/launch/racer_gazebo.launch
+++ b/ros_ws/src/simulation/racer_world/launch/racer_gazebo.launch
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
 
-  <arg name="world" default="racetrack_decorated"/> 
+  <arg name="world" default="racetrack_decorated"/>
   <arg name="paused" default="false"/>
   <arg name="use_sim_time" default="true"/>
   <arg name="gui" default="true"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
-  <arg name="verbose" value="true"/>
-  
+  <arg name="verbose" default="true"/>
+
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find racer_world)/worlds/$(arg world).world"/>
     <arg name="paused" value="$(arg paused)"/>
@@ -18,12 +18,11 @@
     <arg name="debug" value="$(arg debug)"/>
     <arg name="verbose" value="$(arg verbose)"/>
   </include>
-  
+
   <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find racer_description)/urdf/racer.xacro'"/>
 
-  <node name="racer_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
-   args="-urdf -param robot_description -model racer" />
-   
+  <node name="racer_spawn" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model racer" />
+
   <include file="$(find racer_control)/launch/racer_control.launch"/>
 
 </launch>

--- a/ros_ws/src/simulation/racer_world/launch/racer_gazebo_rviz.launch
+++ b/ros_ws/src/simulation/racer_world/launch/racer_gazebo_rviz.launch
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
 
-  <arg name="world" default="racetrack_decorated"/> 
+  <arg name="world" default="racetrack_decorated"/>
   <arg name="paused" default="false"/>
   <arg name="use_sim_time" default="true"/>
   <arg name="gui" default="true"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
-  <arg name="verbose" value="true"/>
-  
+  <arg name="verbose" default="true"/>
+
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find racer_world)/worlds/$(arg world).world"/>
     <arg name="paused" value="$(arg paused)"/>
@@ -18,12 +18,11 @@
     <arg name="debug" value="$(arg debug)"/>
     <arg name="verbose" value="$(arg verbose)"/>
   </include>
-  
+
   <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find racer_description)/urdf/racer.xacro'"/>
 
-  <node name="racer_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
-   args="-urdf -param robot_description -model racer" />
-   
+  <node name="racer_spawn" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model racer" />
+
   <include file="$(find racer_control)/launch/racer_control.launch"/>
 
   <!-- Show in Rviz   -->


### PR DESCRIPTION
Some launch files are currently supporting command line arguments (e.g. joystick_type) but those cannot be set to a specific value yet. This PR fixes that.