### PR TITLE
Add option whether to use gpu for lidar sim or not

### DIFF
--- a/ros_ws/launch/gazebo_car-autonomous.launch
+++ b/ros_ws/launch/gazebo_car-autonomous.launch
@@ -7,6 +7,7 @@
     <arg name="headless" default="false"/>
     <arg name="debug" default="false"/>
     <arg name="verbose" default="true"/>
+    <arg name="use_gpu" default="true"/>
 
     <include file="$(find racer_world)/launch/racer_gazebo_rviz.launch">
         <arg name="world" value="$(arg world)"/>
@@ -16,6 +17,7 @@
         <arg name="headless" value="$(arg headless)"/>
         <arg name="debug" value="$(arg debug)"/>
         <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="use_gpu" value="$(arg use_gpu)"/>
     </include>
 
     <include file="$(find autonomous)/launch/autonomous_driving.launch"/>

--- a/ros_ws/launch/gazebo_car-teleop.launch
+++ b/ros_ws/launch/gazebo_car-teleop.launch
@@ -8,6 +8,7 @@
     <arg name="debug" default="false"/>
     <arg name="verbose" default="true"/>
     <arg name="joystick_type" default="xbox360"/>
+    <arg name="use_gpu" default="true"/>
 
     <include file="$(find racer_world)/launch/racer_gazebo_rviz.launch">
         <arg name="world" value="$(arg world)"/>
@@ -17,6 +18,7 @@
         <arg name="headless" value="$(arg headless)"/>
         <arg name="debug" value="$(arg debug)"/>
         <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="use_gpu" value="$(arg use_gpu)"/>
     </include>
 
     <include file="$(find vesc_sim)/launch/vesc_sim.launch"/>

--- a/ros_ws/src/simulation/racer_description/urdf/racer_plugins.gazebo
+++ b/ros_ws/src/simulation/racer_description/urdf/racer_plugins.gazebo
@@ -62,7 +62,7 @@
 
   <!-- Hokuyo -->
   <gazebo reference="hokuyo">
-    <sensor type="gpu_ray" name="head_hokuyo_sensor">
+    <sensor type="ray" name="head_hokuyo_sensor">
       <pose>0 0 0 0 0 0</pose>
       <visualize>true</visualize>
       <update_rate>40</update_rate>
@@ -90,7 +90,7 @@
           <stddev>0.01</stddev>
         </noise>
       </ray>
-      <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_gpu_laser.so">
+      <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_laser.so">
         <topicName>/racer/laser/scan</topicName>
         <frameName>hokuyo</frameName>
       </plugin>

--- a/ros_ws/src/simulation/racer_description/urdf/racer_plugins.gazebo
+++ b/ros_ws/src/simulation/racer_description/urdf/racer_plugins.gazebo
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Gazebo plugins -->
   <gazebo>
@@ -61,8 +61,17 @@
   </gazebo>
 
   <!-- Hokuyo -->
+  <xacro:if value="$(arg use_gpu)">
+    <xacro:property name="hokuyo_sensor" value="gpu_ray"/>
+    <xacro:property name="hokuyo_plugin" value="libgazebo_ros_gpu_laser.so"/>
+  </xacro:if>
+  <xacro:unless value="$(arg use_gpu)">
+    <xacro:property name="hokuyo_sensor" value="ray"/>
+    <xacro:property name="hokuyo_plugin" value="libgazebo_ros_laser.so"/>
+  </xacro:unless>
+
   <gazebo reference="hokuyo">
-    <sensor type="ray" name="head_hokuyo_sensor">
+    <sensor type="${hokuyo_sensor}" name="head_hokuyo_sensor">
       <pose>0 0 0 0 0 0</pose>
       <visualize>true</visualize>
       <update_rate>40</update_rate>
@@ -90,7 +99,7 @@
           <stddev>0.01</stddev>
         </noise>
       </ray>
-      <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_laser.so">
+      <plugin name="gazebo_ros_head_hokuyo_controller" filename="${hokuyo_plugin}">
         <topicName>/racer/laser/scan</topicName>
         <frameName>hokuyo</frameName>
       </plugin>

--- a/ros_ws/src/simulation/racer_world/launch/racer_gazebo.launch
+++ b/ros_ws/src/simulation/racer_world/launch/racer_gazebo.launch
@@ -8,6 +8,7 @@
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
   <arg name="verbose" default="true"/>
+  <arg name="use_gpu" default="true"/>
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find racer_world)/worlds/$(arg world).world"/>
@@ -19,7 +20,7 @@
     <arg name="verbose" value="$(arg verbose)"/>
   </include>
 
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find racer_description)/urdf/racer.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find racer_description)/urdf/racer.xacro' use_gpu:=$(arg use_gpu)"/>
 
   <node name="racer_spawn" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model racer" />
 

--- a/ros_ws/src/simulation/racer_world/launch/racer_gazebo_rviz.launch
+++ b/ros_ws/src/simulation/racer_world/launch/racer_gazebo_rviz.launch
@@ -8,6 +8,7 @@
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
   <arg name="verbose" default="true"/>
+  <arg name="use_gpu" default="true"/>
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find racer_world)/worlds/$(arg world).world"/>
@@ -19,7 +20,7 @@
     <arg name="verbose" value="$(arg verbose)"/>
   </include>
 
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find racer_description)/urdf/racer.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find racer_description)/urdf/racer.xacro' use_gpu:=$(arg use_gpu)"/>
 
   <node name="racer_spawn" pkg="gazebo_ros" type="spawn_model" output="screen" args="-urdf -param robot_description -model racer" />
 


### PR DESCRIPTION
I don't have a dedicated graphics card on my machine which results in the gazebo simulation not showing those blue lines for the lidar and rviz not showing the red dots. I have now added an option to not use the gpu for simulating the lidar which fixes this problem for me. For those without this problem this doesn't affect you in any way.