### PR TITLE
Refactor Dead Man's Switch to publish its state as a boolean

### DIFF
--- a/ros_ws/src/car_control/include/car_control.h
+++ b/ros_ws/src/car_control/include/car_control.h
@@ -10,5 +10,5 @@ constexpr const char* TOPIC_FOCBOX_ANGLE = "/commands/servo/position";
 constexpr const char* TOPIC_FOCBOX_BRAKE = "commands/motor/brake";
 
 constexpr const char* TOPIC_DRIVE_PARAM = "/set/drive_param";
-constexpr const char* TOPIC_COMMAND = "/command";
-constexpr const char* TOPIC_DMS = "/set/dms";
+constexpr const char* TOPIC_UNLOCK_MOTOR = "/unlock_motor";
+constexpr const char* TOPIC_DMS_HEARTBEAT = "/set/dms";

--- a/ros_ws/src/car_control/include/car_controller.h
+++ b/ros_ws/src/car_control/include/car_controller.h
@@ -44,5 +44,8 @@ class CarController
      */
     void publishDriveParameters(double raw_speed, double raw_angle);
 
+    /**
+     * @brief publishes a brake message that stops the car
+     */
     void stop();
 };

--- a/ros_ws/src/car_control/include/car_controller.h
+++ b/ros_ws/src/car_control/include/car_controller.h
@@ -6,8 +6,8 @@
 #include <time.h>
 
 #include <drive_msgs/drive_param.h>
+#include <std_msgs/Bool.h>
 #include <std_msgs/Float64.h>
-#include <std_msgs/String.h>
 
 constexpr const int MAX_SPEED = 5000;
 constexpr const double MAX_ANGLE = 0.9;
@@ -21,33 +21,28 @@ class CarController
     ros::NodeHandle m_node_handle;
 
     ros::Subscriber m_drive_parameters_subscriber;
-    ros::Subscriber m_command_subscriber;
+    ros::Subscriber m_unlock_motor_subscriber;
 
     ros::Publisher m_speed_pulisher;
     ros::Publisher m_angle_publisher;
     ros::Publisher m_brake_publisher;
 
-    bool m_enabled;
+    bool m_motor_unlocked;
 
     /**
      * @brief deals with incomming drive param messages
-     *
-     * @param parameters
      */
     void driveParametersCallback(const drive_msgs::drive_param::ConstPtr& parameters);
 
     /**
-     * @brief executes incomming commands
-     *
-     * @param command_message
+     * @brief callback for the topic that enables / disables the motor
      */
-    void commandCallback(const std_msgs::String::ConstPtr& command_message);
+    void unlockMotorCallback(const std_msgs::Bool::ConstPtr& unlock_motor_message);
 
     /**
      * @brief takes a speed and angle, converts and forwards them to gazebo/focbox
-     *
-     * @param raw_speed
-     * @param raw_angle
      */
     void publishDriveParameters(double raw_speed, double raw_angle);
+
+    void stop();
 };

--- a/ros_ws/src/car_control/include/dms_controller.h
+++ b/ros_ws/src/car_control/include/dms_controller.h
@@ -3,34 +3,31 @@
 #include <ros/ros.h>
 
 #include <chrono>
+#include <std_msgs/Bool.h>
 #include <std_msgs/Int64.h>
-#include <std_msgs/String.h>
 
 constexpr const char* PARAMETER_DMS_CHECK_RATE = "dms_check_rate";
 constexpr const char* PARAMETER_DMS_EXPIRATION = "dms_expiration";
 
-// How old the last dead mans switch check can be, in seconds
-constexpr auto DMS_EXPIRATION = std::chrono::duration<double>(0.1);
-
 class DMSController
 {
     public:
-    int dms_check_rate; // How often the dead mans switch is checked. in Hz
-    int dms_expiration; // How old the last dead mans switch check can be. in ms
     DMSController();
-    void checkDMS();
+
+    void spin();
 
     private:
-    std::chrono::steady_clock::time_point m_last_dms_message_received;
-    bool m_running = false;
-    ros::NodeHandle m_node_handle;
-    ros::Subscriber m_dms_subscriber;
-    ros::Publisher m_command_pulisher;
+    int m_update_frequency;                          // How often the unlock motor message is published, in Hz
+    std::chrono::duration<double> m_expiration_time; // How old the last dead man's switch heartbeat can be, in ms
 
-    /**
-     * @brief checks the m_last_dms_message_received with the rate DMS_CHECK_RATE
-     *
-     * @param dms_message
-     */
-    void dmsCallback(const std_msgs::Int64::ConstPtr& dms_message);
+    std::chrono::steady_clock::time_point m_last_heartbeat_received;
+
+    ros::NodeHandle m_node_handle;
+    ros::Subscriber m_heartbeat_subscriber;
+    ros::Publisher m_unlock_motor_publisher;
+
+    void configureParameters();
+    void publishUnlockMotor();
+
+    void heartbeatCallback(const std_msgs::Int64::ConstPtr& dms_message);
 };

--- a/ros_ws/src/car_control/include/dms_controller.h
+++ b/ros_ws/src/car_control/include/dms_controller.h
@@ -17,8 +17,15 @@ class DMSController
     void spin();
 
     private:
-    int m_update_frequency;                          // How often the unlock motor message is published, in Hz
-    std::chrono::duration<double> m_expiration_time; // How old the last dead man's switch heartbeat can be, in ms
+    /**
+     * @brief How often the unlock motor message is published, in Hz
+     */
+    int m_update_frequency;
+
+    /**
+     * @brief How old the last dead man's switch heartbeat can be, in ms
+     */
+    std::chrono::duration<double> m_expiration_time;
 
     std::chrono::steady_clock::time_point m_last_heartbeat_received;
 

--- a/ros_ws/src/car_control/src/car_controller.cpp
+++ b/ros_ws/src/car_control/src/car_controller.cpp
@@ -11,8 +11,7 @@ CarController::CarController()
         this->m_node_handle.subscribe<drive_msgs::drive_param>(TOPIC_DRIVE_PARAM, 1,
                                                                &CarController::driveParametersCallback, this);
     this->m_unlock_motor_subscriber =
-        this->m_node_handle.subscribe<std_msgs::Bool>(TOPIC_UNLOCK_MOTOR, 1, &CarController::unlockMotorCallback,
-                                                      this);
+        this->m_node_handle.subscribe<std_msgs::Bool>(TOPIC_UNLOCK_MOTOR, 1, &CarController::unlockMotorCallback, this);
 
     this->m_speed_pulisher = this->m_node_handle.advertise<std_msgs::Float64>(TOPIC_FOCBOX_SPEED, 1);
     this->m_angle_publisher = this->m_node_handle.advertise<std_msgs::Float64>(TOPIC_FOCBOX_ANGLE, 1);

--- a/ros_ws/src/car_control/src/car_controller.cpp
+++ b/ros_ws/src/car_control/src/car_controller.cpp
@@ -5,13 +5,14 @@
 #include <boost/algorithm/clamp.hpp>
 
 CarController::CarController()
-    : m_enabled{ false }
+    : m_motor_unlocked{ false }
 {
     this->m_drive_parameters_subscriber =
         this->m_node_handle.subscribe<drive_msgs::drive_param>(TOPIC_DRIVE_PARAM, 1,
                                                                &CarController::driveParametersCallback, this);
-    this->m_command_subscriber =
-        this->m_node_handle.subscribe<std_msgs::String>(TOPIC_COMMAND, 1, &CarController::commandCallback, this);
+    this->m_unlock_motor_subscriber =
+        this->m_node_handle.subscribe<std_msgs::Bool>(TOPIC_UNLOCK_MOTOR, 1, &CarController::unlockMotorCallback,
+                                                      this);
 
     this->m_speed_pulisher = this->m_node_handle.advertise<std_msgs::Float64>(TOPIC_FOCBOX_SPEED, 1);
     this->m_angle_publisher = this->m_node_handle.advertise<std_msgs::Float64>(TOPIC_FOCBOX_ANGLE, 1);
@@ -20,45 +21,45 @@ CarController::CarController()
 
 void CarController::driveParametersCallback(const drive_msgs::drive_param::ConstPtr& parameters)
 {
-    float velocity = boost::algorithm::clamp(parameters->velocity, -1.0f, 1.0f);
-    float angle = boost::algorithm::clamp(parameters->angle, -1.0f, 1.0f);
-    this->publishDriveParameters(velocity, angle);
+    if (this->m_motor_unlocked)
+    {
+        this->publishDriveParameters(parameters->velocity, parameters->angle);
+    }
 }
 
-void CarController::publishDriveParameters(double raw_speed, double raw_angle)
+void CarController::publishDriveParameters(double relative_speed, double relative_angle)
 {
-    double speed = raw_speed * car_config::MAX_RPM_ELECTRICAL;
-    double angle = (raw_angle * car_config::MAX_SERVO_POSITION + car_config::MAX_SERVO_POSITION) / 2;
+    double speed = relative_speed * car_config::MAX_RPM_ELECTRICAL;
+    double angle = (relative_angle * car_config::MAX_SERVO_POSITION + car_config::MAX_SERVO_POSITION) / 2;
 
-    if (this->m_enabled)
-    {
-        std_msgs::Float64 speed_message;
-        speed_message.data = speed;
-        this->m_speed_pulisher.publish(speed_message);
-        std_msgs::Float64 angle_message;
-        angle_message.data = angle;
-        this->m_angle_publisher.publish(angle_message);
-    }
-    ROS_DEBUG_STREAM("running: " << this->m_enabled << " | speed: " << speed << " | angle: " << angle);
+    std_msgs::Float64 speed_message;
+    speed_message.data = speed;
+    this->m_speed_pulisher.publish(speed_message);
+
+    std_msgs::Float64 angle_message;
+    angle_message.data = angle;
+    this->m_angle_publisher.publish(angle_message);
+
+    ROS_DEBUG_STREAM("running: "
+                     << " | speed: " << speed << " | angle: " << angle);
 }
 
-void CarController::commandCallback(const std_msgs::String::ConstPtr& command_message)
+void CarController::unlockMotorCallback(const std_msgs::Bool::ConstPtr& unlock_motor_message)
 {
-    std::string command_str = command_message->data;
-    if (command_str.compare(COMMAND_STOP) == 0)
+    if (this->m_motor_unlocked && !unlock_motor_message->data)
     {
-        this->publishDriveParameters(0, 0);
-        this->m_enabled = false;
-        // brake
-        std_msgs::Float64 brake_message;
-        brake_message.data = 0;
-        this->m_brake_publisher.publish(brake_message);
+        this->stop();
     }
-    if (command_str.compare(COMMAND_GO) == 0)
-    {
-        this->m_enabled = true;
-    }
-    ROS_INFO_STREAM("command input: " << command_str);
+    this->m_motor_unlocked = unlock_motor_message->data;
+}
+
+void CarController::stop()
+{
+    this->publishDriveParameters(0, 0);
+
+    std_msgs::Float64 brake_message;
+    brake_message.data = 0;
+    this->m_brake_publisher.publish(brake_message);
 }
 
 int main(int argc, char** argv)

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -8,15 +8,12 @@
 #include <ros/package.h>
 #include <ros/ros.h>
 #include <signal.h>
-#include <std_msgs/String.h>
+#include <std_msgs/Bool.h>
 #include <stdexcept>
 
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "input/drive_param/keyboard";
 constexpr const char* TOPIC_DEAD_MANS_SWITCH = "/set/dms";
-constexpr const char* TOPIC_COMMAND = "/command";
-
-constexpr const char* COMMAND_STOP = "stop";
-constexpr const char* COMMAND_GO = "go";
+constexpr const char* TOPIC_UNLOCK_MOTOR = "/unlock_motor";
 
 enum class Keycode : int
 {
@@ -74,7 +71,7 @@ class KeyboardController
     ros::Publisher m_drive_parameters_publisher;
     ros::Publisher m_dead_mans_switch_publisher;
 
-    ros::Subscriber m_command_subscriber;
+    ros::Subscriber m_unlock_motor_subscriber;
 
     SDL_Window* m_window;
 
@@ -97,6 +94,6 @@ class KeyboardController
 
     void createWindow();
     void timerCallback(const ros::TimerEvent& event);
-    void commandCallback(const std_msgs::String::ConstPtr& command_message);
+    void unlockMotorCallback(const std_msgs::Bool::ConstPtr& unlock_motor_message);
     void updateWindowColor();
 };

--- a/ros_ws/src/teleoperation/src/keyboard_controller.cpp
+++ b/ros_ws/src/teleoperation/src/keyboard_controller.cpp
@@ -25,8 +25,9 @@ KeyboardController::KeyboardController()
     this->m_drive_parameters_publisher =
         this->m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAMETERS, 1);
     this->m_dead_mans_switch_publisher = this->m_node_handle.advertise<std_msgs::Int64>(TOPIC_DEAD_MANS_SWITCH, 1);
-    this->m_command_subscriber =
-        this->m_node_handle.subscribe<std_msgs::String>(TOPIC_COMMAND, 1, &KeyboardController::commandCallback, this);
+    this->m_unlock_motor_subscriber =
+        this->m_node_handle.subscribe<std_msgs::Bool>(TOPIC_UNLOCK_MOTOR, 1, &KeyboardController::unlockMotorCallback,
+                                                      this);
 
     this->createWindow();
 
@@ -184,17 +185,11 @@ void KeyboardController::publishDriveParameters()
     this->m_drive_parameters_publisher.publish(drive_parameters);
 }
 
-void KeyboardController::commandCallback(const std_msgs::String::ConstPtr& command_message)
+void KeyboardController::unlockMotorCallback(const std_msgs::Bool::ConstPtr& unlock_motor_message)
 {
-    std::string command = command_message->data;
-    if (command.compare(COMMAND_STOP) == 0)
+    if (this->m_car_unlocked != unlock_motor_message->data)
     {
-        this->m_car_unlocked = false;
-        this->updateWindowColor();
-    }
-    else if (command.compare(COMMAND_GO) == 0)
-    {
-        this->m_car_unlocked = true;
+        this->m_car_unlocked = unlock_motor_message->data;
         this->updateWindowColor();
     }
 }


### PR DESCRIPTION
Dead Man's Switch no longer uses "stop" and "go" commands. Some DMS related code has been simplified.

Fixes #170 