### PR TITLE
Wallfollowing improvements

### DIFF
--- a/ros_ws/launch/car-autonomous.launch
+++ b/ros_ws/launch/car-autonomous.launch
@@ -1,0 +1,25 @@
+<launch>
+    <arg name="joystick_type" default="ps3"/>
+
+    <include file="$(find car_control)/launch/car_control.launch"/>
+
+    <include file="$(find teleoperation)/launch/remote_control.launch">
+        <arg name="joystick_type" value="$(arg joystick_type)"/>
+    </include>
+
+    <include file="$(find vesc_driver)/launch/vesc_driver_node.launch"/>
+    
+    <!-- Passing parameters to the vesc_to_odom node doesn't currently work-->
+    <!--<node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom_node"
+        output="screen" launch-prefix="" >
+        <param name="speed_to_erpm_gain" value="64.96"/>
+        <param name="speed_to_erpm_offset" value="0"/>
+        <param name="steering_angle_to_servo_gain" value="-0.95492965"/>
+        <param name="steering_angle_to_servo_offset" value="0.5"/>
+        <param name="wheelbase" value="0.325"/>
+    </node>-->
+
+    <include file="$(find autonomous)/launch/autonomous_driving.launch"/>
+
+    <node name="rviz" pkg="rviz" type="rviz" args=""/>
+</launch>

--- a/ros_ws/src/autonomous/CMakeLists.txt
+++ b/ros_ws/src/autonomous/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(
 )
 
 # wall following node 
-add_executable(wall_following src/wall_following.cpp src/pid_controller.cpp)
+add_executable(wall_following src/wall_following.cpp src/pid_controller.cpp src/rviz_geometry_publisher.cpp)
 target_link_libraries(wall_following ${catkin_LIBRARIES})
 add_dependencies(wall_following ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 

--- a/ros_ws/src/autonomous/CMakeLists.txt
+++ b/ros_ws/src/autonomous/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(
 )
 
 # wall following node 
-add_executable(wall_following src/wall_following.cpp src/pid_controller.cpp src/rviz_geometry_publisher.cpp)
+add_executable(wall_following src/wall_following.cpp src/pid_controller.cpp src/rviz_geometry_publisher.cpp src/wall.cpp)
 target_link_libraries(wall_following ${catkin_LIBRARIES})
 add_dependencies(wall_following ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 

--- a/ros_ws/src/autonomous/include/rviz_geometry_publisher.h
+++ b/ros_ws/src/autonomous/include/rviz_geometry_publisher.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include "std_msgs/ColorRGBA.h"
 #include <ros/ros.h>

--- a/ros_ws/src/autonomous/include/rviz_geometry_publisher.h
+++ b/ros_ws/src/autonomous/include/rviz_geometry_publisher.h
@@ -1,0 +1,20 @@
+
+#include "std_msgs/ColorRGBA.h"
+#include <ros/ros.h>
+#include <visualization_msgs/Marker.h>
+
+geometry_msgs::Point createPoint(double x, double y, double z);
+std_msgs::ColorRGBA createColor(double r, double g, double b, double a);
+
+class RvizGeometryPublisher
+{
+    public:
+    RvizGeometryPublisher(ros::NodeHandle node_handle, const std::string& topic, const std::string& frame);
+
+    void drawLine(int id, geometry_msgs::Point point1, geometry_msgs::Point point2, std_msgs::ColorRGBA color,
+                  float width);
+
+    private:
+    ros::Publisher m_marker_publisher;
+    const std::string m_frame;
+};

--- a/ros_ws/src/autonomous/include/wall.h
+++ b/ros_ws/src/autonomous/include/wall.h
@@ -1,0 +1,18 @@
+#include "rviz_geometry_publisher.h"
+#include <cmath>
+#include <cstdlib>
+
+class Wall
+{
+    public:
+    float m_angle1;
+    float m_angle2;
+    float m_range1;
+    float m_range2;
+
+    float getAngle();
+
+    float predictDistance(float distancce_to_current_position);
+
+    void draw(RvizGeometryPublisher& geometry, int id, std_msgs::ColorRGBA color);
+};

--- a/ros_ws/src/autonomous/include/wall.h
+++ b/ros_ws/src/autonomous/include/wall.h
@@ -10,6 +10,8 @@ class Wall
     float m_range1;
     float m_range2;
 
+    Wall(float angle1, float angle2, float range1, float range2);
+
     float getAngle();
 
     float predictDistance(float distancce_to_current_position);

--- a/ros_ws/src/autonomous/include/wall_following.h
+++ b/ros_ws/src/autonomous/include/wall_following.h
@@ -30,10 +30,10 @@ constexpr float SAMPLE_ANGLE_1 = 40 * DEG_TO_RAD;
 constexpr float SAMPLE_ANGLE_2 = 90 * DEG_TO_RAD;
 
 constexpr float WALL_FOLLOWING_MAX_SPEED = 0.25;
-constexpr float WALL_FOLLOWING_MIN_SPEED = 0.1;
+constexpr float WALL_FOLLOWING_MIN_SPEED = 0.15;
 
 // The car will aim to reach the target wall distance after travelling this distance
-constexpr float PREDICTION_DISTANCE = 0.5;
+constexpr float PREDICTION_DISTANCE = 1;
 // The desired distance between the wall and the car
 constexpr float TARGET_WALL_DISTANCE = 0.5;
 
@@ -56,7 +56,8 @@ class WallFollowing
 
     PIDController m_pid_controller = PIDController(120, 0.48, 7.5);
 
-    void followWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall);
+    void followSingleWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall);
+    void followWalls(const sensor_msgs::LaserScan::ConstPtr& lidar);
     Wall getWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall);
 
     void emergencyStopCallback(const std_msgs::Bool emergency_stop_message);

--- a/ros_ws/src/autonomous/include/wall_following.h
+++ b/ros_ws/src/autonomous/include/wall_following.h
@@ -30,7 +30,7 @@ constexpr float SAMPLE_ANGLE_1 = 40 * DEG_TO_RAD;
 constexpr float SAMPLE_ANGLE_2 = 90 * DEG_TO_RAD;
 
 constexpr float WALL_FOLLOWING_MAX_SPEED = 0.25;
-constexpr float WALL_FOLLOWING_MIN_SPEED = 0.15;
+constexpr float WALL_FOLLOWING_MIN_SPEED = 0.2;
 
 // The car will aim to reach the target wall distance after travelling this distance
 constexpr float PREDICTION_DISTANCE = 1;

--- a/ros_ws/src/autonomous/include/wall_following.h
+++ b/ros_ws/src/autonomous/include/wall_following.h
@@ -17,8 +17,6 @@ constexpr const char* TOPIC_LASER_SCAN = "/scan";
 constexpr const char* TOPIC_EMERGENCY_STOP = "/emergency_stop";
 constexpr const char* TOPIC_VISUALIZATION = "/wallfollowing_visualization";
 
-constexpr int LIDAR_SAMPLE_COUNT = 720;
-
 // Discard lidar measurements outside this range
 constexpr float MIN_RANGE = 0.2;
 constexpr float MAX_RANGE = 30;

--- a/ros_ws/src/autonomous/include/wall_following.h
+++ b/ros_ws/src/autonomous/include/wall_following.h
@@ -26,14 +26,15 @@ constexpr float MAX_RANGE = 30;
 
 constexpr float FALLBACK_RANGE = 4;
 
-constexpr float SAMPLE_ANGLE_1 = 40 * DEG_TO_RAD;
-constexpr float SAMPLE_ANGLE_2 = 90 * DEG_TO_RAD;
+constexpr float SAMPLE_ANGLE_1 = 30 * DEG_TO_RAD;
+constexpr float SAMPLE_ANGLE_2 = 70 * DEG_TO_RAD;
 
 constexpr float WALL_FOLLOWING_MAX_SPEED = 0.25;
 constexpr float WALL_FOLLOWING_MIN_SPEED = 0.2;
 
-// The car will aim to reach the target wall distance after travelling this distance
-constexpr float PREDICTION_DISTANCE = 1;
+// The car will aim to reach the target wall distance after travelling this distance.
+// The higher this number, the more aggressively the car will cut corners.
+constexpr float PREDICTION_DISTANCE = 2;
 // The desired distance between the wall and the car
 constexpr float TARGET_WALL_DISTANCE = 0.5;
 
@@ -54,7 +55,7 @@ class WallFollowing
 
     bool m_emergency_stop = true;
 
-    PIDController m_pid_controller = PIDController(120, 0.48, 7.5);
+    PIDController m_pid_controller = PIDController(6, 0.01, 0.3);
 
     void followSingleWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall);
     void followWalls(const sensor_msgs::LaserScan::ConstPtr& lidar);

--- a/ros_ws/src/autonomous/include/wall_following.h
+++ b/ros_ws/src/autonomous/include/wall_following.h
@@ -17,14 +17,16 @@ constexpr const char* TOPIC_LASER_SCAN = "/scan";
 constexpr const char* TOPIC_EMERGENCY_STOP = "/emergency_stop";
 constexpr const char* TOPIC_VISUALIZATION = "/wallfollowing_visualization";
 
+constexpr float DEG_TO_RAD = M_PI / 180.0;
+
 // Discard lidar measurements outside this range
 constexpr float MIN_RANGE = 0.2;
 constexpr float MAX_RANGE = 30;
 
 constexpr float FALLBACK_RANGE = 4;
 
-constexpr float SAMPLE_ANGLE_1 = 40;
-constexpr float SAMPLE_ANGLE_2 = 90;
+constexpr float SAMPLE_ANGLE_1 = 40 * DEG_TO_RAD;
+constexpr float SAMPLE_ANGLE_2 = 90 * DEG_TO_RAD;
 constexpr float SAMPLE_WINDOW_SIZE = SAMPLE_ANGLE_2 - SAMPLE_ANGLE_1;
 
 constexpr float WALL_FOLLOWING_MAX_SPEED = 0.25;
@@ -36,8 +38,6 @@ constexpr float PREDICTION_DISTANCE = 0.5;
 constexpr float TARGET_WALL_DISTANCE = 0.5;
 
 constexpr float TIME_BETWEEN_SCANS = 0.025;
-
-constexpr float DEG_TO_RAD = M_PI / 180.0;
 
 class WallFollowing
 {

--- a/ros_ws/src/autonomous/include/wall_following.h
+++ b/ros_ws/src/autonomous/include/wall_following.h
@@ -9,6 +9,7 @@
 #include "sensor_msgs/LaserScan.h"
 #include "std_msgs/Bool.h"
 #include "std_msgs/Float64.h"
+#include "wall.h"
 #include <ros/console.h>
 #include <ros/ros.h>
 
@@ -27,7 +28,6 @@ constexpr float FALLBACK_RANGE = 4;
 
 constexpr float SAMPLE_ANGLE_1 = 40 * DEG_TO_RAD;
 constexpr float SAMPLE_ANGLE_2 = 90 * DEG_TO_RAD;
-constexpr float SAMPLE_WINDOW_SIZE = SAMPLE_ANGLE_2 - SAMPLE_ANGLE_1;
 
 constexpr float WALL_FOLLOWING_MAX_SPEED = 0.25;
 constexpr float WALL_FOLLOWING_MIN_SPEED = 0.1;
@@ -50,15 +50,14 @@ class WallFollowing
     ros::Subscriber m_emergency_stop_subscriber;
     ros::Subscriber m_lidar_subscriber;
     ros::Publisher m_drive_parameter_publisher;
-
     RvizGeometryPublisher m_debug_geometry;
 
-    bool m_follow_right_wall = false;
     bool m_emergency_stop = true;
 
     PIDController m_pid_controller = PIDController(120, 0.48, 7.5);
 
-    void followWall(const sensor_msgs::LaserScan::ConstPtr& lidar);
+    void followWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall);
+    Wall getWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall);
 
     void emergencyStopCallback(const std_msgs::Bool emergency_stop_message);
     void lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar);

--- a/ros_ws/src/autonomous/include/wall_following.h
+++ b/ros_ws/src/autonomous/include/wall_following.h
@@ -5,6 +5,7 @@
 
 #include "drive_msgs/drive_param.h"
 #include "pid_controller.h"
+#include "rviz_geometry_publisher.h"
 #include "sensor_msgs/LaserScan.h"
 #include "std_msgs/Bool.h"
 #include "std_msgs/Float64.h"
@@ -14,6 +15,7 @@
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "/input/drive_param/wallfollowing";
 constexpr const char* TOPIC_LASER_SCAN = "/scan";
 constexpr const char* TOPIC_EMERGENCY_STOP = "/emergency_stop";
+constexpr const char* TOPIC_VISUALIZATION = "/wallfollowing_visualization";
 
 constexpr int LIDAR_SAMPLE_COUNT = 720;
 
@@ -50,6 +52,8 @@ class WallFollowing
     ros::Subscriber m_emergency_stop_subscriber;
     ros::Subscriber m_lidar_subscriber;
     ros::Publisher m_drive_parameter_publisher;
+
+    RvizGeometryPublisher m_debug_geometry;
 
     bool m_follow_right_wall = false;
     bool m_emergency_stop = true;

--- a/ros_ws/src/autonomous/src/rviz_geometry_publisher.cpp
+++ b/ros_ws/src/autonomous/src/rviz_geometry_publisher.cpp
@@ -1,0 +1,48 @@
+#include "rviz_geometry_publisher.h"
+
+RvizGeometryPublisher::RvizGeometryPublisher(ros::NodeHandle node_handle, const std::string& topic,
+                                             const std::string& frame)
+    : m_frame(frame)
+{
+    this->m_marker_publisher = node_handle.advertise<visualization_msgs::Marker>(topic, 10);
+}
+
+void RvizGeometryPublisher::drawLine(int id, geometry_msgs::Point point1, geometry_msgs::Point point2,
+                                     std_msgs::ColorRGBA color, float width)
+{
+    visualization_msgs::Marker line_list;
+    line_list.header.frame_id = this->m_frame;
+    line_list.header.stamp = ros::Time::now();
+    line_list.ns = "points_and_lines";
+    line_list.action = visualization_msgs::Marker::ADD;
+    line_list.pose.orientation.w = 1.0;
+
+    line_list.id = id;
+    line_list.type = visualization_msgs::Marker::LINE_LIST;
+    line_list.scale.x = width;
+    line_list.color = color;
+
+    line_list.points.push_back(point1);
+    line_list.points.push_back(point2);
+
+    this->m_marker_publisher.publish(line_list);
+}
+
+geometry_msgs::Point createPoint(double x, double y, double z)
+{
+    geometry_msgs::Point p;
+    p.x = x;
+    p.y = y;
+    p.z = z;
+    return p;
+}
+
+std_msgs::ColorRGBA createColor(double r, double g, double b, double a)
+{
+    std_msgs::ColorRGBA c;
+    c.r = r;
+    c.g = g;
+    c.b = b;
+    c.a = a;
+    return c;
+}

--- a/ros_ws/src/autonomous/src/wall.cpp
+++ b/ros_ws/src/autonomous/src/wall.cpp
@@ -1,0 +1,20 @@
+#include "wall.h"
+
+float Wall::getAngle()
+{
+    return atan((m_range1 * cos(std::abs(m_angle1 - m_angle2)) - m_range2) / m_range1 *
+                sin(std::abs(m_angle1 - m_angle2)));
+}
+
+float Wall::predictDistance(float distancce_to_current_position)
+{
+    float angle = this->getAngle();
+    float currentWallDistance = m_range2 * cos(angle);
+    return currentWallDistance + distancce_to_current_position * sin(angle);
+}
+
+void Wall::draw(RvizGeometryPublisher& geometry, int id, std_msgs::ColorRGBA color)
+{
+    geometry.drawLine(id, createPoint(m_range1 * cos(m_angle1), m_range1 * sin(m_angle1), 0.0),
+                      createPoint(m_range2 * cos(m_angle2), m_range2 * sin(m_angle2), 0.0), color, 0.03);
+}

--- a/ros_ws/src/autonomous/src/wall.cpp
+++ b/ros_ws/src/autonomous/src/wall.cpp
@@ -1,5 +1,13 @@
 #include "wall.h"
 
+Wall::Wall(float angle1, float angle2, float range1, float range2)
+    : m_angle1{ angle1 }
+    , m_angle2{ angle2 }
+    , m_range1{ range1 }
+    , m_range2{ range2 }
+{
+}
+
 float Wall::getAngle()
 {
     return atan((m_range1 * cos(std::abs(m_angle1 - m_angle2)) - m_range2) / m_range1 *

--- a/ros_ws/src/autonomous/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/src/wall_following.cpp
@@ -66,7 +66,7 @@ void WallFollowing::followSingleWall(const sensor_msgs::LaserScan::ConstPtr& lid
     float error = TARGET_WALL_DISTANCE - predictedWallDistance;
     float correction = this->m_pid_controller.updateAndGetCorrection(error, TIME_BETWEEN_SCANS);
 
-    float steeringAngle = atan(leftRightSign * correction * DEG_TO_RAD);
+    float steeringAngle = atan(leftRightSign * correction) * 2 / M_PI;
     float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - std::abs(steeringAngle));
     velocity = boost::algorithm::clamp(velocity, WALL_FOLLOWING_MIN_SPEED, WALL_FOLLOWING_MAX_SPEED);
 
@@ -91,7 +91,7 @@ void WallFollowing::followWalls(const sensor_msgs::LaserScan::ConstPtr& lidar)
     float error = (rightWall.predictDistance(PREDICTION_DISTANCE) - leftWall.predictDistance(PREDICTION_DISTANCE)) / 2;
     float correction = this->m_pid_controller.updateAndGetCorrection(error, TIME_BETWEEN_SCANS);
 
-    float steeringAngle = atan(correction * DEG_TO_RAD);
+    float steeringAngle = atan(correction) * 2 / M_PI;;
     float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - std::abs(steeringAngle));
     velocity = boost::algorithm::clamp(velocity, WALL_FOLLOWING_MIN_SPEED, WALL_FOLLOWING_MAX_SPEED);
 

--- a/ros_ws/src/autonomous/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/src/wall_following.cpp
@@ -37,16 +37,14 @@ float WallFollowing::getRangeAtDegree(const sensor_msgs::LaserScan::ConstPtr& li
 
 Wall WallFollowing::getWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall)
 {
-    Wall wall;
     float leftRightSign = right_wall ? -1 : 1;
 
-    wall.m_angle1 = SAMPLE_ANGLE_1 * leftRightSign;
-    wall.m_angle2 = SAMPLE_ANGLE_2 * leftRightSign;
+    float angle1 = SAMPLE_ANGLE_1 * leftRightSign;
+    float angle2 = SAMPLE_ANGLE_2 * leftRightSign;
+    float range1 = this->getRangeAtDegree(lidar, angle1);
+    float range2 = this->getRangeAtDegree(lidar, angle2);
 
-    wall.m_range1 = this->getRangeAtDegree(lidar, wall.m_angle1);
-    wall.m_range2 = this->getRangeAtDegree(lidar, wall.m_angle2);
-
-    return wall;
+    return Wall(angle1, angle2, range1, range2);
 }
 
 /**

--- a/ros_ws/src/autonomous/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/src/wall_following.cpp
@@ -20,7 +20,7 @@ float map(float in_lower, float in_upper, float out_lower, float out_upper, floa
 float WallFollowing::getRangeAtDegree(const sensor_msgs::LaserScan::ConstPtr& lidar, float angle)
 {
     int sampleCount = (lidar->angle_max - lidar->angle_min) / lidar->angle_increment;
-    int index = map(lidar->angle_min, lidar->angle_max, 0, sampleCount, angle * DEG_TO_RAD);
+    int index = map(lidar->angle_min, lidar->angle_max, 0, sampleCount, angle);
     
     // clang-format off
     if (index < 0
@@ -51,8 +51,8 @@ void WallFollowing::followWall(const sensor_msgs::LaserScan::ConstPtr& lidar)
     float range1 = this->getRangeAtDegree(lidar, SAMPLE_ANGLE_1 * leftRightSign);
     float range2 = this->getRangeAtDegree(lidar, SAMPLE_ANGLE_2 * leftRightSign);
 
-    float wallAngle = atan((range1 * cos(SAMPLE_WINDOW_SIZE * DEG_TO_RAD) - range2) /
-                           (range1 * sin(SAMPLE_WINDOW_SIZE * DEG_TO_RAD)));
+    float wallAngle = atan((range1 * cos(SAMPLE_WINDOW_SIZE) - range2) /
+                           (range1 * sin(SAMPLE_WINDOW_SIZE)));
     float currentWallDistance = range2 * cos(wallAngle);
     float predictedWallDistance = currentWallDistance + PREDICTION_DISTANCE * sin(wallAngle);
 
@@ -63,10 +63,10 @@ void WallFollowing::followWall(const sensor_msgs::LaserScan::ConstPtr& lidar)
     float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - std::abs(steeringAngle));
     velocity = boost::algorithm::clamp(velocity, WALL_FOLLOWING_MIN_SPEED, WALL_FOLLOWING_MAX_SPEED);
 
-    this->m_debug_geometry.drawLine(0, createPoint(range1 * cos(SAMPLE_ANGLE_1 * leftRightSign * DEG_TO_RAD),
-                                                   range1 * sin(SAMPLE_ANGLE_1 * leftRightSign * DEG_TO_RAD), 0.0),
-                                    createPoint(range2 * cos(SAMPLE_ANGLE_2 * leftRightSign * DEG_TO_RAD),
-                                                range2 * sin(SAMPLE_ANGLE_2 * leftRightSign * DEG_TO_RAD), 0.0),
+    this->m_debug_geometry.drawLine(0, createPoint(range1 * cos(SAMPLE_ANGLE_1 * leftRightSign),
+                                                   range1 * sin(SAMPLE_ANGLE_1 * leftRightSign), 0.0),
+                                    createPoint(range2 * cos(SAMPLE_ANGLE_2 * leftRightSign),
+                                                range2 * sin(SAMPLE_ANGLE_2 * leftRightSign), 0.0),
                                     createColor(0, 1, 0, 1), 0.03);
     this->m_debug_geometry.drawLine(1, createPoint(PREDICTION_DISTANCE, 0, 0),
                                     createPoint(PREDICTION_DISTANCE, -error, 0), createColor(1, 0, 0, 1), 0.03);

--- a/ros_ws/src/autonomous/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/src/wall_following.cpp
@@ -19,11 +19,12 @@ float map(float in_lower, float in_upper, float out_lower, float out_upper, floa
 
 float WallFollowing::getRangeAtDegree(const sensor_msgs::LaserScan::ConstPtr& lidar, float angle)
 {
-    int index = map(lidar->angle_min, lidar->angle_max, 0, LIDAR_SAMPLE_COUNT, angle * DEG_TO_RAD);
-
+    int sampleCount = (lidar->angle_max - lidar->angle_min) / lidar->angle_increment;
+    int index = map(lidar->angle_min, lidar->angle_max, 0, sampleCount, angle * DEG_TO_RAD);
+    
     // clang-format off
     if (index < 0
-        || index >= LIDAR_SAMPLE_COUNT
+        || index >= sampleCount
         || lidar->ranges[index] < MIN_RANGE
         || lidar->ranges[index] > MAX_RANGE) {
         ROS_INFO_STREAM("Could not sample lidar, using fallback value");

--- a/ros_ws/src/simulation/racer_world/launch/myrobot.rviz
+++ b/ros_ws/src/simulation/racer_world/launch/myrobot.rviz
@@ -159,9 +159,18 @@ Visualization Manager:
       Visibility:
         Grid: true
         LaserScan: true
+        Marker: true
         RobotModel: true
         Value: true
       Zoom Factor: 1
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: wallfollowing_visualization
+      Name: Marker
+      Namespaces:
+        points_and_lines: true
+      Queue Size: 100
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48


### PR DESCRIPTION
- Visualize detected wall in rviz
- Don't use a hardcoded number for the amount of samples in the lidar since it's different on the simulated and real car
- Implement double wall following

Currently, code changes are required to switch between following the left, right or both walls. This should be changed once we know how these modes perform.