### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,63 +2,85 @@
 sudo: true
 dist: xenial
 
-
-branches:
-  except:
-    - gh-pages
-
-addons:
-  apt:
-    packages:
-      - doxygen
-      - doxygen-doc
-      - doxygen-latex
-      - doxygen-gui
-      - graphviz
-      - libeigen3-dev
-
-cache:
-    apt: true
-    ccache: true
-
-language: cpp
-
-matrix:
+jobs:
   include:
-  - name: "ROS kinetic"
-    env: ROS_DISTRO=kinetic
+    - # build project
+      branches:
+        except:
+          - gh-pages
+          - master
 
-env:
-  global:
-    - SRC_PATH=$(pwd)
-    - GH_REPO_NAME: ros.package
-    - DOXYFILE: $TRAVIS_BUILD_DIR/docs/master/Doxyfile
-    - GH_REPO_REF: github.com/Autonomous-Racing-PG/ros.package.git
+      if: type = pullrequest
 
-before_install:
-  - cd ros_ws
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-  - sudo apt-get update -qq
-  - sudo apt-get install -y "ros-${ROS_DISTRO}-desktop-full"
-  - sudo apt-get install python-wstool
-  - sudo apt-get install libsdl2-dev
-  - source /opt/ros/${ROS_DISTRO}/setup.bash
-  - sudo rosdep init
-  - rosdep update
+      addons:
+        apt:
+          packages:
+            - libeigen3-dev
+            - python-wstool
+            - clang
+            - clang-format
+            - libsdl2-dev
 
-before_script:
-  - wstool init
-  - wstool up
-  - source /opt/ros/${ROS_DISTRO}/setup.bash
-  - rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}
+      cache:
+          apt: true
+          ccache: true
 
-script:
-  - source /opt/ros/${ROS_DISTRO}/setup.bash
-  - catkin_make 
-  - catkin_make run_tests && catkin_test_results
+      language: cpp
 
-after_success:
-  - cd $TRAVIS_BUILD_DIR
-  - chmod 755 ./scripts/travis/doxygen/generate-doxygen-doc.sh
-  - ./scripts/travis/doxygen/generate-doxygen-doc.sh
+      matrix:
+        include:
+        - name: "ROS kinetic"
+          env: ROS_DISTRO=kinetic
+
+      env:
+        global:
+          - SRC_PATH=$(pwd)
+          - GH_REPO_NAME: ros.package
+          - GH_REPO_REF: github.com/Autonomous-Racing-PG/ros.package.git
+
+      before_install:
+        - cd ros_ws
+        - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+        - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+        - sudo apt-get update -qq
+        - sudo apt-get install -y "ros-${ROS_DISTRO}-desktop-full"
+        - source /opt/ros/${ROS_DISTRO}/setup.bash
+        - sudo rosdep init
+        - rosdep update
+
+      before_script:
+        - wstool init
+        - wstool up
+        - source /opt/ros/${ROS_DISTRO}/setup.bash
+        - rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}
+
+      script:
+        - source /opt/ros/${ROS_DISTRO}/setup.bash
+        - catkin_make 
+        - catkin_make run_tests && catkin_test_results
+      
+    - # create documentation
+      addons:
+        apt:
+          packages:
+            - doxygen
+            - doxygen-doc
+            - doxygen-latex
+            - doxygen-gui
+            - graphviz
+
+      cache:
+          apt: true
+          ccache: true
+      
+      env:
+        global:
+          - SRC_PATH=$(pwd)
+          - GH_REPO_NAME: ros.package
+          - DOXYFILE: $TRAVIS_BUILD_DIR/docs/master/Doxyfile
+          - GH_REPO_REF: github.com/Autonomous-Racing-PG/ros.package.git
+
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - chmod 755 ./scripts/travis/doxygen/generate-doxygen-doc.sh
+        - ./scripts/travis/doxygen/generate-doxygen-doc.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
   - sudo apt-get install -y "ros-${ROS_DISTRO}-desktop-full"
-  - sudo apt-get install clang
-  - sudo apt-get install clang-format
   - sudo apt-get install python-wstool
   - sudo apt-get install libsdl2-dev
   - source /opt/ros/${ROS_DISTRO}/setup.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,48 +2,36 @@
 sudo: true
 dist: xenial
 
+env:
+  global:
+    - SRC_PATH=$(pwd)
+    - ROS_DISTRO: kinetic
+    - GH_REPO_NAME: ros.package
+    - DOXYFILE: $TRAVIS_BUILD_DIR/docs/master/Doxyfile
+    - GH_REPO_REF: github.com/Autonomous-Racing-PG/ros.package.git
+
 jobs:
   include:
     - # build project
-      branches:
-        except:
-          - gh-pages
-          - master
-
-      if: type = pullrequest
+      if: type = pull_request
 
       addons:
         apt:
           packages:
             - libeigen3-dev
             - python-wstool
-            - clang
-            - clang-format
             - libsdl2-dev
 
       cache:
           apt: true
-          ccache: true
-
-      language: cpp
-
-      matrix:
-        include:
-        - name: "ROS kinetic"
-          env: ROS_DISTRO=kinetic
-
-      env:
-        global:
-          - SRC_PATH=$(pwd)
-          - GH_REPO_NAME: ros.package
-          - GH_REPO_REF: github.com/Autonomous-Racing-PG/ros.package.git
+          ccache: true      
 
       before_install:
         - cd ros_ws
         - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
         - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
         - sudo apt-get update -qq
-        - sudo apt-get install -y "ros-${ROS_DISTRO}-desktop-full"
+        - sudo apt-get install -y "ros-${ROS_DISTRO}-ros-base"
         - source /opt/ros/${ROS_DISTRO}/setup.bash
         - sudo rosdep init
         - rosdep update
@@ -60,6 +48,8 @@ jobs:
         - catkin_make run_tests && catkin_test_results
       
     - # create documentation
+      if: type != pull_request AND branch = master
+      
       addons:
         apt:
           packages:
@@ -72,13 +62,6 @@ jobs:
       cache:
           apt: true
           ccache: true
-      
-      env:
-        global:
-          - SRC_PATH=$(pwd)
-          - GH_REPO_NAME: ros.package
-          - DOXYFILE: $TRAVIS_BUILD_DIR/docs/master/Doxyfile
-          - GH_REPO_REF: github.com/Autonomous-Racing-PG/ros.package.git
 
       script:
         - cd $TRAVIS_BUILD_DIR

--- a/scripts/travis/doxygen/generate-doxygen-doc.sh
+++ b/scripts/travis/doxygen/generate-doxygen-doc.sh
@@ -3,21 +3,6 @@ cd $TRAVIS_BUILD_DIR
 
 ###################### REWRITE ##########################
 
-# check for pull-requests
-if ! [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
-    echo 'Not running Doxygen for pull-requests.'
-    exit 0
-fi
-
-# check for branch name
-if ! [[ "${TRAVIS_BRANCH}" = "master" ]]; then
-    echo "Running Doxygen only for updates on 'master' branch (current: ${TRAVIS_BRANCH})."
-    exit 0
-fi
-
-
-###################### REWRITE ##########################
-
 # Create a clean working directory for this script.
 mkdir docs
 cd docs


### PR DESCRIPTION
- Split cpp build and doxygen into separate travis jobs
- Ros project is only built for pullrequests, documentation is only built for pushes to master
- The check for doxygen was moved from the bash script to the travis configuration so that no VM is created if doxygen will not be run
- Remove some unused dependencies (Rviz and doxygen are no longer installed for cpp builds)
- Unfortunately, gazebo is still installed which takes about 90 seconds. This is due to the fact that the `--skip-keys` option for `rosdep` is broken.