### PR TITLE
fixed implicit conversion from ‘float’ to ‘double’ warning

### DIFF
--- a/ros_ws/src/autonomous/src/wall.cpp
+++ b/ros_ws/src/autonomous/src/wall.cpp
@@ -10,19 +10,19 @@ Wall::Wall(float angle1, float angle2, float range1, float range2)
 
 float Wall::getAngle()
 {
-    return atan((m_range1 * (float)cos(std::abs(m_angle1 - m_angle2)) - m_range2) / m_range1 *
-                (float)sin(std::abs(m_angle1 - m_angle2)));
+    return std::atan((m_range1 * std::cos(std::abs(m_angle1 - m_angle2)) - m_range2) / m_range1 *
+                std::sin(std::abs(m_angle1 - m_angle2)));
 }
 
 float Wall::predictDistance(float distancce_to_current_position)
 {
     float angle = this->getAngle();
-    float currentWallDistance = m_range2 * (float)cos(angle);
-    return currentWallDistance + distancce_to_current_position * (float)sin(angle);
+    float currentWallDistance = m_range2 * std::cos(angle);
+    return currentWallDistance + distancce_to_current_position * std::sin(angle);
 }
 
 void Wall::draw(RvizGeometryPublisher& geometry, int id, std_msgs::ColorRGBA color)
 {
-    geometry.drawLine(id, createPoint(m_range1 * (float)cos(m_angle1), m_range1 * (float)sin(m_angle1), 0.0),
-                      createPoint(m_range2 * (float)cos(m_angle2), m_range2 * (float)sin(m_angle2), 0.0), color, 0.03);
+    geometry.drawLine(id, createPoint(m_range1 * std::cos(m_angle1), m_range1 * std::sin(m_angle1), 0.0f),
+                      createPoint(m_range2 * std::cos(m_angle2), m_range2 * std::sin(m_angle2), 0.0f), color, 0.03);
 }

--- a/ros_ws/src/autonomous/src/wall.cpp
+++ b/ros_ws/src/autonomous/src/wall.cpp
@@ -10,19 +10,19 @@ Wall::Wall(float angle1, float angle2, float range1, float range2)
 
 float Wall::getAngle()
 {
-    return atan((m_range1 * cos(std::abs(m_angle1 - m_angle2)) - m_range2) / m_range1 *
-                sin(std::abs(m_angle1 - m_angle2)));
+    return atan((m_range1 * (float)cos(std::abs(m_angle1 - m_angle2)) - m_range2) / m_range1 *
+                (float)sin(std::abs(m_angle1 - m_angle2)));
 }
 
 float Wall::predictDistance(float distancce_to_current_position)
 {
     float angle = this->getAngle();
-    float currentWallDistance = m_range2 * cos(angle);
-    return currentWallDistance + distancce_to_current_position * sin(angle);
+    float currentWallDistance = m_range2 * (float)cos(angle);
+    return currentWallDistance + distancce_to_current_position * (float)sin(angle);
 }
 
 void Wall::draw(RvizGeometryPublisher& geometry, int id, std_msgs::ColorRGBA color)
 {
-    geometry.drawLine(id, createPoint(m_range1 * cos(m_angle1), m_range1 * sin(m_angle1), 0.0),
-                      createPoint(m_range2 * cos(m_angle2), m_range2 * sin(m_angle2), 0.0), color, 0.03);
+    geometry.drawLine(id, createPoint(m_range1 * (float)cos(m_angle1), m_range1 * (float)sin(m_angle1), 0.0),
+                      createPoint(m_range2 * (float)cos(m_angle2), m_range2 * (float)sin(m_angle2), 0.0), color, 0.03);
 }

--- a/ros_ws/src/autonomous/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/src/wall_following.cpp
@@ -76,8 +76,8 @@ void WallFollowing::followSingleWall(const sensor_msgs::LaserScan::ConstPtr& lid
                                     createColor(1, 0, 0, 1), 0.03);
     float wallAngle = wall.getAngle();
     this->m_debug_geometry.drawLine(2, createPoint(PREDICTION_DISTANCE, -error * leftRightSign, 0),
-                                    createPoint(PREDICTION_DISTANCE + (float)cos(wallAngle) * 2,
-                                                (-error + (float)sin(wallAngle) * 2) * leftRightSign, 0),
+                                    createPoint(PREDICTION_DISTANCE + std::cos(wallAngle) * 2,
+                                                (-error + std::sin(wallAngle) * 2) * leftRightSign, 0),
                                     createColor(0, 1, 1, 1), 0.03);
 
     this->publishDriveParameters(velocity, steeringAngle);
@@ -92,7 +92,7 @@ void WallFollowing::followWalls(const sensor_msgs::LaserScan::ConstPtr& lidar)
     float correction = this->m_pid_controller.updateAndGetCorrection(error, TIME_BETWEEN_SCANS);
 
     float steeringAngle = atan(correction) * 2 / M_PI;
-    float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - (float)std::max(0.0, (double)std::abs(steeringAngle) - 0.15));
+    float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - std::max(0.0f, std::abs(steeringAngle) - 0.15f));
     velocity = boost::algorithm::clamp(velocity, WALL_FOLLOWING_MIN_SPEED, WALL_FOLLOWING_MAX_SPEED);
 
     leftWall.draw(this->m_debug_geometry, 0, createColor(0, 0, 1, 1));

--- a/ros_ws/src/autonomous/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/src/wall_following.cpp
@@ -76,8 +76,8 @@ void WallFollowing::followSingleWall(const sensor_msgs::LaserScan::ConstPtr& lid
                                     createColor(1, 0, 0, 1), 0.03);
     float wallAngle = wall.getAngle();
     this->m_debug_geometry.drawLine(2, createPoint(PREDICTION_DISTANCE, -error * leftRightSign, 0),
-                                    createPoint(PREDICTION_DISTANCE + cos(wallAngle) * 2,
-                                                (-error + sin(wallAngle) * 2) * leftRightSign, 0),
+                                    createPoint(PREDICTION_DISTANCE + (float)cos(wallAngle) * 2,
+                                                (-error + (float)sin(wallAngle) * 2) * leftRightSign, 0),
                                     createColor(0, 1, 1, 1), 0.03);
 
     this->publishDriveParameters(velocity, steeringAngle);
@@ -92,7 +92,7 @@ void WallFollowing::followWalls(const sensor_msgs::LaserScan::ConstPtr& lidar)
     float correction = this->m_pid_controller.updateAndGetCorrection(error, TIME_BETWEEN_SCANS);
 
     float steeringAngle = atan(correction) * 2 / M_PI;
-    float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - std::max(0.0, std::abs(steeringAngle) - 0.15));
+    float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - (float)std::max(0.0, (double)std::abs(steeringAngle) - 0.15));
     velocity = boost::algorithm::clamp(velocity, WALL_FOLLOWING_MIN_SPEED, WALL_FOLLOWING_MAX_SPEED);
 
     leftWall.draw(this->m_debug_geometry, 0, createColor(0, 0, 1, 1));


### PR DESCRIPTION
fixed implicit conversion from ‘float’ to ‘double’ warning.

An other option could be to change all float variables to double.