### PR TITLE
Removed unneeded dependency that caused a warning

### DIFF
--- a/ros_ws/src/simulation/racer_description/package.xml
+++ b/ros_ws/src/simulation/racer_description/package.xml
@@ -13,6 +13,5 @@
 
   <!-- Dependencies -->
   <depend>catkin</depend>
-  <depend>ros_controllers</depend>
 
 </package>


### PR DESCRIPTION
Fixes the warning 

"WARNING: package "racer_description" should not depend on metapackage "ros_controllers" but on its packages instead"

that appeared each time the workspace was build from scratch.