### PR TITLE
Remove install_joy script

### DIFF
--- a/scripts/install_joy.sh
+++ b/scripts/install_joy.sh
@@ -1,2 +1,0 @@
-sudo apt-get install ros-kinetic-joy
-


### PR DESCRIPTION
Since missing packages can now be installed with rosdep this script has become useless.