### PR TITLE
Fixed maximum velocity of the simulated car

### DIFF
--- a/ros_ws/src/simulation/racer_description/urdf/racer_macros.xacro
+++ b/ros_ws/src/simulation/racer_description/urdf/racer_macros.xacro
@@ -60,7 +60,7 @@
       <child link="${lr}_wheel_${fb}"/>
       <origin xyz="${translateX * OffsetJointX} ${translateY * OffsetJointY} ${OffsetJointZ}" rpy="0 0 0" /> 
       <axis xyz="0 1 0" rpy="0 0 0" />
-      <limit effort="10" velocity="100"/>
+      <limit effort="20" velocity="500"/>
       <joint_properties damping="0.0" friction="0.0"/>
     </joint>
 


### PR DESCRIPTION
This PR changes the maximal velocity of the simulated car from ~5.2m/s (erroneous value) to ~17.1m/s (expected value). Please note that both the keyboard and joystick controller by default limit the speed to 35% of the max value, so to test this PR you need to change either `MAX_THROTTLE` in `keyboard_controller.h` or `ACCELERATION_SCALING_FACTOR` in `joystick_controller.h`.