### PR TITLE
Added dynamic configuration to teleoperation, emergency stop and wallfollowing1

### DIFF
--- a/ros_ws/src/autonomous/emergency_stop/CMakeLists.txt
+++ b/ros_ws/src/autonomous/emergency_stop/CMakeLists.txt
@@ -9,11 +9,20 @@ find_package(catkin REQUIRED COMPONENTS
   drive_msgs
   roscpp
   std_msgs
+  dynamic_reconfigure
 )
 
 ## Errors and Warnings
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
 # -Wpedantic cant be used because of ROS
+
+#########################
+## Dynamic Reconfigure ##
+#########################
+
+generate_dynamic_reconfigure_options(
+  cfg/emergency_stop.cfg
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -38,4 +47,5 @@ include_directories(
 # emergency stop node
 add_executable(emergency_stop src/emergency_stop.cpp)
 target_link_libraries(emergency_stop ${catkin_LIBRARIES})
+add_dependencies(emergency_stop ${${PROJECT_NAME}_EXPORTED_TARGETS}_gencfg)
 add_dependencies(emergency_stop ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/ros_ws/src/autonomous/emergency_stop/cfg/emergency_stop.cfg
+++ b/ros_ws/src/autonomous/emergency_stop/cfg/emergency_stop.cfg
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+from dynamic_reconfigure.parameter_generator_catkin import *
+PACKAGE = "emergency_stop"
+
+
+gen = ParameterGenerator()
+
+gen.add("range_threshold", double_t, 0, "TODO Tooltip", 0.7, 0.0001)
+gen.add("car_bumper_length", double_t, 0, "TODO Tooltip", 0.2, 0.0001)
+gen.add("max_range", double_t, 0, "TODO Tooltip", 30, 0.0001)
+
+exit(gen.generate(PACKAGE, "emergency_stop", "emergency_stop"))

--- a/ros_ws/src/autonomous/emergency_stop/include/emergency_stop.h
+++ b/ros_ws/src/autonomous/emergency_stop/include/emergency_stop.h
@@ -10,15 +10,13 @@
 #include <ros/console.h>
 #include <ros/ros.h>
 
+#include <dynamic_reconfigure/server.h>
+#include <emergency_stop/emergency_stopConfig.h>
+
 constexpr float DEG_TO_RAD = M_PI / 180.0;
 
 constexpr const char* TOPIC_LASER_SCAN = "/scan";
 constexpr const char* TOPIC_EMERGENCY_STOP = "/input/emergencystop";
-
-constexpr float RANGE_THRESHOLD = 0.7;
-constexpr const float CAR_BUMPER_LENGTH = 0.2;
-
-constexpr float MAX_RANGE = 30;
 
 class EmergencyStop
 {
@@ -31,10 +29,18 @@ class EmergencyStop
      */
     bool emergencyStop(const sensor_msgs::LaserScan::ConstPtr& lidar);
 
+    dynamic_reconfigure::Server<emergency_stop::emergency_stopConfig> m_dyn_cfg_server;
+
+    float m_range_threshold = 0.7;
+    float m_car_bumper_length = 0.2;
+    float m_max_range = 30;
+
     ros::NodeHandle m_node_handle;
     ros::Subscriber m_lidar_subscriber;
 
     void lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar);
+
+    void updateDynamicConfig();
 
     ros::Publisher m_emergency_stop_publisher;
 };

--- a/ros_ws/src/autonomous/emergency_stop/package.xml
+++ b/ros_ws/src/autonomous/emergency_stop/package.xml
@@ -20,5 +20,6 @@
   <depend>drive_msgs</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
+  <depend>dynamic_reconfigure</depend>
 
 </package>

--- a/ros_ws/src/autonomous/emergency_stop/src/emergency_stop.cpp
+++ b/ros_ws/src/autonomous/emergency_stop/src/emergency_stop.cpp
@@ -6,21 +6,29 @@ EmergencyStop::EmergencyStop()
     m_lidar_subscriber =
         m_node_handle.subscribe<sensor_msgs::LaserScan>(TOPIC_LASER_SCAN, 1, &EmergencyStop::lidarCallback, this);
     m_emergency_stop_publisher = m_node_handle.advertise<std_msgs::Time>(TOPIC_EMERGENCY_STOP, 1);
+
+    this->updateDynamicConfig();
+
+    m_dyn_cfg_server.setCallback([&](emergency_stop::emergency_stopConfig& cfg, uint32_t) {
+        m_range_threshold = cfg.range_threshold;
+        m_car_bumper_length = cfg.car_bumper_length;
+        m_max_range = cfg.max_range;
+    });
 }
 
 bool EmergencyStop::emergencyStop(const sensor_msgs::LaserScan::ConstPtr& lidar)
 {
-    ROS_ASSERT_MSG(RANGE_THRESHOLD <= MAX_RANGE,
+    ROS_ASSERT_MSG(m_range_threshold <= m_max_range,
                    "Threshold is bigger then max range. Function will always return false.");
-    ROS_ASSERT_MSG(MAX_RANGE > 0, "Max range is zero or below. Function will mostly return true.");
-    ROS_ASSERT_MSG(RANGE_THRESHOLD > 0, "Threshold is zero or below. Function will mostly return false.");
+    ROS_ASSERT_MSG(m_max_range > 0, "Max range is zero or below. Function will mostly return true.");
+    ROS_ASSERT_MSG(m_range_threshold > 0, "Threshold is zero or below. Function will mostly return false.");
 
     int available_samples = (lidar->angle_max - lidar->angle_min) / lidar->angle_increment;
 
     // calculate the sample_angle of the lidar to be used to check if there is
-    // an obstacle in front of the car, with respect to the RANGE_THRESHOLD
-    // We want to check every lidar sample that is located in front of the car at a distance of RANGE_THRESHOLD.
-    float sample_angle = std::atan(CAR_BUMPER_LENGTH / 2 / RANGE_THRESHOLD);
+    // an obstacle in front of the car, with respect to the m_range_threshold
+    // We want to check every lidar sample that is located in front of the car at a distance of m_range_threshold.
+    float sample_angle = std::atan(m_car_bumper_length / 2 / m_range_threshold);
 
     int index_start = available_samples / 2 - sample_angle / lidar->angle_increment / 2;
     int index_end = available_samples / 2 + sample_angle / lidar->angle_increment / 2;
@@ -31,11 +39,11 @@ bool EmergencyStop::emergencyStop(const sensor_msgs::LaserScan::ConstPtr& lidar)
     // Instead of calculating the range average, we are more cautious because we would
     // rather have false positives instead of false negatives.
     // i.e. we would rather stop too much than crash into an obstacle.
-    auto min_range =
-        std::min(MAX_RANGE, *std::min_element(lidar->ranges.begin() + index_start, lidar->ranges.begin() + index_end));
+    auto min_range = std::min(m_max_range, *std::min_element(lidar->ranges.begin() + index_start,
+                                                             lidar->ranges.begin() + index_end));
     ROS_ASSERT_MSG(min_range >= 0, "The minimal distance between the car and a potential obstacle is below zero.");
 
-    return min_range < RANGE_THRESHOLD;
+    return min_range < m_range_threshold;
 }
 
 void EmergencyStop::lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar)
@@ -51,6 +59,17 @@ void EmergencyStop::lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar)
 
         m_emergency_stop_publisher.publish(message);
     }
+}
+
+void EmergencyStop::updateDynamicConfig()
+{
+    emergency_stop::emergency_stopConfig cfg;
+    {
+        cfg.range_threshold = m_range_threshold;
+        cfg.car_bumper_length = m_car_bumper_length;
+        cfg.max_range = m_max_range;
+    }
+    m_dyn_cfg_server.updateConfig(cfg);
 }
 
 int main(int argc, char** argv)

--- a/ros_ws/src/autonomous/wallfollowing1/CMakeLists.txt
+++ b/ros_ws/src/autonomous/wallfollowing1/CMakeLists.txt
@@ -10,11 +10,20 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
+  dynamic_reconfigure
 )
 
 ## Errors and Warnings
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
 # -Wpedantic cant be used because of ROS
+
+#########################
+## Dynamic Reconfigure ##
+#########################
+
+generate_dynamic_reconfigure_options(
+  cfg/wallfollowing1.cfg
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -24,7 +33,6 @@ set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp
 catkin_package(
   CATKIN_DEPENDS drive_msgs roscpp rospy std_msgs
 )
-
 
 ###########
 ## Build ##
@@ -39,4 +47,5 @@ include_directories(
 # wall following node 
 add_executable(wall_following src/wall_following.cpp src/pid_controller.cpp src/rviz_geometry_publisher.cpp src/wall.cpp)
 target_link_libraries(wall_following ${catkin_LIBRARIES})
+add_dependencies(wall_following ${${PROJECT_NAME}_EXPORTED_TARGETS}_gencfg)
 add_dependencies(wall_following ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/ros_ws/src/autonomous/wallfollowing1/cfg/wallfollowing1.cfg
+++ b/ros_ws/src/autonomous/wallfollowing1/cfg/wallfollowing1.cfg
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+from dynamic_reconfigure.parameter_generator_catkin import *
+PACKAGE = "wallfollowing1"
+
+
+gen = ParameterGenerator()
+
+sub_group = gen.add_group("Valid_lidar_measurement_range")
+sub_group.add("min_range", double_t, 0, "TODO Tooltip", 0.2, 0)
+sub_group.add("max_range", double_t, 0, "TODO Tooltip", 30, 0)
+
+gen.add("fallback_range", double_t, 0, "TODO Tooltip", 4, 0)
+
+gen.add("sample_angle_1", double_t, 0, "TODO Tooltip")
+gen.add("sample_angle_2", double_t, 0, "TODO Tooltip")
+
+gen.add("wall_following_max_speed", double_t, 0, "TODO Tooltip", 0.25, 0)
+gen.add("wall_following_min_speed", double_t, 0, "TODO Tooltip", 0.20, 0)
+
+gen.add(
+    "prediction_distance",
+    double_t,
+    0,
+    "The car will aim to reach the target wall distance after travelling this distance. The higher this number, the more aggressively the car will cut corners.",
+    2,
+    0)
+gen.add(
+    "target_wall_distance",
+    double_t,
+    0,
+    "The desired distance between the wall and the car",
+    0.5,
+    0)
+gen.add("time_between_scans", double_t, 0, "TODO Tooltip", 0.025, 0)
+
+exit(gen.generate(PACKAGE, "wallfollowing1", "wallfollowing1"))

--- a/ros_ws/src/autonomous/wallfollowing1/package.xml
+++ b/ros_ws/src/autonomous/wallfollowing1/package.xml
@@ -18,5 +18,6 @@
   <depend>roscpp</depend>
   <depend>rospy</depend>
   <depend>std_msgs</depend>
+  <depend>dynamic_reconfigure</depend>
 
 </package>

--- a/ros_ws/src/autonomous/wallfollowing1/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/wallfollowing1/src/wall_following.cpp
@@ -7,6 +7,27 @@ WallFollowing::WallFollowing()
     this->m_lidar_subscriber =
         m_node_handle.subscribe<sensor_msgs::LaserScan>(TOPIC_LASER_SCAN, 1, &WallFollowing::lidarCallback, this);
     this->m_drive_parameter_publisher = m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAMETERS, 1);
+
+    this->updateDynamicConfig();
+
+    m_dyn_cfg_server.setCallback([&](wallfollowing1::wallfollowing1Config& cfg, uint32_t) {
+        m_min_range = cfg.min_range;
+        m_max_range = cfg.max_range;
+
+        m_fallback_range = cfg.fallback_range;
+
+        m_sample_angle_1 = static_cast<float>(cfg.sample_angle_1) * DEG_TO_RAD;
+        m_sample_angle_2 = static_cast<float>(cfg.sample_angle_2) * DEG_TO_RAD;
+
+        m_wall_following_max_speed = cfg.wall_following_max_speed;
+        m_wall_following_min_speed = cfg.wall_following_min_speed;
+
+        m_prediction_distance = cfg.prediction_distance;
+
+        m_target_wall_distance = cfg.target_wall_distance;
+
+        m_time_between_scans = cfg.time_between_scans;
+    });
 }
 
 // map value in range [in_lower, in_upper] to the corresponding number in range [out_lower, out_upper]
@@ -23,10 +44,10 @@ float WallFollowing::getRangeAtDegree(const sensor_msgs::LaserScan::ConstPtr& li
     // clang-format off
     if (index < 0
         || index >= sampleCount
-        || lidar->ranges[index] < MIN_RANGE
-        || lidar->ranges[index] > MAX_RANGE) {
+        || lidar->ranges[index] < m_min_range
+        || lidar->ranges[index] > m_max_range) {
         ROS_INFO_STREAM("Could not sample lidar, using fallback value");
-        return FALLBACK_RANGE;
+        return m_fallback_range;
     }
     // clang-format on
 
@@ -37,8 +58,8 @@ Wall WallFollowing::getWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool 
 {
     float leftRightSign = right_wall ? -1 : 1;
 
-    float angle1 = SAMPLE_ANGLE_1 * leftRightSign;
-    float angle2 = SAMPLE_ANGLE_2 * leftRightSign;
+    float angle1 = m_sample_angle_1 * leftRightSign;
+    float angle2 = m_sample_angle_2 * leftRightSign;
     float range1 = this->getRangeAtDegree(lidar, angle1);
     float range2 = this->getRangeAtDegree(lidar, angle2);
 
@@ -49,7 +70,7 @@ Wall WallFollowing::getWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool 
  * @brief This method attempts to follow either the right or left wall.
  * It samples two points next to the car and estimates a straight wall based on them.
  * The predicted distance is the distance between the wall and the position that the car
- * will have after it drives straight forward for PREDICTION_DISTANCE meters.
+ * will have after it drives straight forward for m_prediction_distance meters.
  * A PID controller is used to minimize the difference between the predicted distance
  * to the wall and TARGET_DISTANCE.
  * The calculation is based on this document: http://f1tenth.org/lab_instructions/t6.pdf
@@ -59,22 +80,22 @@ void WallFollowing::followSingleWall(const sensor_msgs::LaserScan::ConstPtr& lid
     float leftRightSign = right_wall ? -1 : 1;
 
     Wall wall = this->getWall(lidar, right_wall);
-    float predictedWallDistance = wall.predictDistance(PREDICTION_DISTANCE);
+    float predictedWallDistance = wall.predictDistance(m_prediction_distance);
 
-    float error = TARGET_WALL_DISTANCE - predictedWallDistance;
-    float correction = this->m_pid_controller.updateAndGetCorrection(error, TIME_BETWEEN_SCANS);
+    float error = m_target_wall_distance - predictedWallDistance;
+    float correction = this->m_pid_controller.updateAndGetCorrection(error, m_time_between_scans);
 
     float steeringAngle = atan(leftRightSign * correction) * 2 / M_PI;
-    float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - std::abs(steeringAngle));
-    velocity = boost::algorithm::clamp(velocity, WALL_FOLLOWING_MIN_SPEED, WALL_FOLLOWING_MAX_SPEED);
+    float velocity = m_wall_following_max_speed * (1 - std::abs(steeringAngle));
+    velocity = boost::algorithm::clamp(velocity, m_wall_following_min_speed, m_wall_following_max_speed);
 
     wall.draw(this->m_debug_geometry, 0, createColor(0, 0, 1, 1));
-    this->m_debug_geometry.drawLine(1, createPoint(PREDICTION_DISTANCE, 0, 0),
-                                    createPoint(PREDICTION_DISTANCE, -error * leftRightSign, 0),
+    this->m_debug_geometry.drawLine(1, createPoint(m_prediction_distance, 0, 0),
+                                    createPoint(m_prediction_distance, -error * leftRightSign, 0),
                                     createColor(1, 0, 0, 1), 0.03);
     float wallAngle = wall.getAngle();
-    this->m_debug_geometry.drawLine(2, createPoint(PREDICTION_DISTANCE, -error * leftRightSign, 0),
-                                    createPoint(PREDICTION_DISTANCE + std::cos(wallAngle) * 2,
+    this->m_debug_geometry.drawLine(2, createPoint(m_prediction_distance, -error * leftRightSign, 0),
+                                    createPoint(m_prediction_distance + std::cos(wallAngle) * 2,
                                                 (-error + std::sin(wallAngle) * 2) * leftRightSign, 0),
                                     createColor(0, 1, 1, 1), 0.03);
 
@@ -86,20 +107,21 @@ void WallFollowing::followWalls(const sensor_msgs::LaserScan::ConstPtr& lidar)
     Wall leftWall = this->getWall(lidar, false);
     Wall rightWall = this->getWall(lidar, true);
 
-    float error = (rightWall.predictDistance(PREDICTION_DISTANCE) - leftWall.predictDistance(PREDICTION_DISTANCE)) / 2;
-    float correction = this->m_pid_controller.updateAndGetCorrection(error, TIME_BETWEEN_SCANS);
+    float error =
+        (rightWall.predictDistance(m_prediction_distance) - leftWall.predictDistance(m_prediction_distance)) / 2;
+    float correction = this->m_pid_controller.updateAndGetCorrection(error, m_time_between_scans);
 
     float steeringAngle = atan(correction) * 2 / M_PI;
-    float velocity = WALL_FOLLOWING_MAX_SPEED * (1 - std::max(0.0f, std::abs(steeringAngle) - 0.15f));
-    velocity = boost::algorithm::clamp(velocity, WALL_FOLLOWING_MIN_SPEED, WALL_FOLLOWING_MAX_SPEED);
+    float velocity = m_wall_following_max_speed * (1 - std::max(0.0f, std::abs(steeringAngle) - 0.15f));
+    velocity = boost::algorithm::clamp(velocity, m_wall_following_min_speed, m_wall_following_max_speed);
 
     leftWall.draw(this->m_debug_geometry, 0, createColor(0, 0, 1, 1));
     rightWall.draw(this->m_debug_geometry, 1, createColor(0, 0, 1, 1));
-    this->m_debug_geometry.drawLine(2, createPoint(PREDICTION_DISTANCE, 0, 0),
-                                    createPoint(PREDICTION_DISTANCE, -error, 0), createColor(1, 0, 0, 1), 0.03);
-    float distance2 = PREDICTION_DISTANCE + 2;
+    this->m_debug_geometry.drawLine(2, createPoint(m_prediction_distance, 0, 0),
+                                    createPoint(m_prediction_distance, -error, 0), createColor(1, 0, 0, 1), 0.03);
+    float distance2 = m_prediction_distance + 2;
     this->m_debug_geometry.drawLine(
-        3, createPoint(PREDICTION_DISTANCE, -error, 0),
+        3, createPoint(m_prediction_distance, -error, 0),
         createPoint(distance2, -(rightWall.predictDistance(distance2) - leftWall.predictDistance(distance2)) / 2, 0),
         createColor(0, 1, 1, 1), 0.03);
 
@@ -117,6 +139,30 @@ void WallFollowing::publishDriveParameters(float velocity, float angle)
 void WallFollowing::lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar)
 {
     this->followWalls(lidar);
+}
+
+void WallFollowing::updateDynamicConfig()
+{
+    wallfollowing1::wallfollowing1Config cfg;
+    {
+        cfg.min_range = m_min_range;
+        cfg.max_range = m_max_range;
+
+        cfg.fallback_range = m_fallback_range;
+
+        cfg.sample_angle_1 = m_sample_angle_1 / DEG_TO_RAD;
+        cfg.sample_angle_2 = m_sample_angle_2 / DEG_TO_RAD;
+
+        cfg.wall_following_max_speed = m_wall_following_max_speed;
+        cfg.wall_following_min_speed = m_wall_following_min_speed;
+
+        cfg.prediction_distance = m_prediction_distance;
+
+        cfg.target_wall_distance = m_target_wall_distance;
+
+        cfg.time_between_scans = m_time_between_scans;
+    }
+    m_dyn_cfg_server.updateConfig(cfg);
 }
 
 int main(int argc, char** argv)

--- a/ros_ws/src/teleoperation/CMakeLists.txt
+++ b/ros_ws/src/teleoperation/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   roslib
+  dynamic_reconfigure
 )
 find_package(SDL2 REQUIRED)
 string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
@@ -18,6 +19,15 @@ set(LIBS ${SDL2_LIBRARIES})
 ## Errors and Warnings
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
 # -Wpedantic cant be used because of ROS
+
+#########################
+## Dynamic Reconfigure ##
+#########################
+
+generate_dynamic_reconfigure_options(
+  cfg/joystick_controller.cfg
+  cfg/keyboard_controller.cfg
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -28,7 +38,6 @@ catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS drive_msgs roscpp std_msgs
 )
-
 
 ###########
 ## Build ##
@@ -44,9 +53,11 @@ include_directories(
 # Declare joystick controller node executable
 add_executable(joystick_controller src/joystick_controller.cpp)
 target_link_libraries(joystick_controller ${LIBS} ${catkin_LIBRARIES})
+add_dependencies(joystick_controller ${${PROJECT_NAME}_EXPORTED_TARGETS}_gencfg)
 add_dependencies(joystick_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 # Declare remote keyboard node executable
 add_executable(keyboard_controller src/keyboard_controller.cpp)
 target_link_libraries(keyboard_controller ${LIBS} ${catkin_LIBRARIES})
+add_dependencies(keyboard_controller ${${PROJECT_NAME}_EXPORTED_TARGETS}_gencfg)
 add_dependencies(keyboard_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/ros_ws/src/teleoperation/cfg/joystick_controller.cfg
+++ b/ros_ws/src/teleoperation/cfg/joystick_controller.cfg
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+from dynamic_reconfigure.parameter_generator_catkin import *
+PACKAGE = "teleoperation"
+
+
+gen = ParameterGenerator()
+
+sub_group = gen.add_group("Joystick")  # , type="tab")
+sub_group.add("joystick_steering_axis", int_t, 0, "TODO Tooltip", 0, 0)
+sub_group.add("joystick_acceleration_axis", int_t, 0, "TODO Tooltip", 4, 0)
+sub_group.add("joystick_deceleration_axis", int_t, 0, "TODO Tooltip", 5, 0)
+sub_group.add("joystick_enable_manual_button", int_t, 0, "TODO Tooltip", 0, 0)
+sub_group.add("joystick_enable_autonomous_button",
+              int_t, 0, "TODO Tooltip", 1, 0)
+
+gen.add("acceleration_scaling_factor", double_t, 0, "TODO Tooltip", 0.35, 0, 1)
+gen.add("deceleration_scaling_factor", double_t, 0, "TODO Tooltip", 0.35, 0, 1)
+gen.add("steering_scaling_factor", double_t, 0, "TODO Tooltip", 0.8, -1, 1)
+
+exit(gen.generate(PACKAGE, "teleoperation", "joystick_controller"))

--- a/ros_ws/src/teleoperation/cfg/keyboard_controller.cfg
+++ b/ros_ws/src/teleoperation/cfg/keyboard_controller.cfg
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+from dynamic_reconfigure.parameter_generator_catkin import *
+PACKAGE = "teleoperation"
+
+
+gen = ParameterGenerator()
+
+gen.add("steering_speed", double_t, 0,
+        "How fast the steering value changes, in units per second", 6)
+gen.add("acceleration", double_t, 0,
+        "How fast the velocity changes, in units per second", 0.4)
+gen.add(
+    "braking",
+    double_t,
+    0,
+    "How fast the velocity changes when decelerating, in units per second",
+    2)
+
+gen.add(
+    "fast_steer_limit",
+    double_t,
+    0,
+    "MAX_STEERING is multiplied by this when travelling at maximum velocity, by 1.0 when resting and by an interpolated value otherwise",
+    0.6)
+gen.add(
+    "steering_gravity",
+    double_t,
+    0,
+    "When no steering key is pressed, the steering value will change towards 0 at this rate, in units per second",
+    2)
+gen.add(
+    "throttle_gravity",
+    double_t,
+    0,
+    "When no throttle key is pressed, the velocity will change towards 0 at this rate, in units per second",
+    3)
+
+gen.add("max_throttle", double_t, 0, "TODO Tooltip", 0.35)
+
+exit(gen.generate(PACKAGE, "teleoperation", "keyboard_controller"))

--- a/ros_ws/src/teleoperation/include/joystick_controller.h
+++ b/ros_ws/src/teleoperation/include/joystick_controller.h
@@ -7,6 +7,9 @@
 #include <sensor_msgs/Joy.h>
 #include <string>
 
+#include <dynamic_reconfigure/server.h>
+#include <teleoperation/joystick_controllerConfig.h>
+
 constexpr const char* PARAMETER_JOYSTICK_TYPE = "joystick_type";
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "input/drive_param/joystick";
 constexpr const char* TOPIC_HEARTBEAT_MANUAL = "/input/heartbeat_manual";
@@ -14,33 +17,34 @@ constexpr const char* TOPIC_HEARTBEAT_AUTONOMOUS = "/input/heartbeat_autonomous"
 
 constexpr float EPSILON = 0.001;
 
-/**
- * @brief scales the absolute acceleration provided by the joystick.
- * Useful if the car should not drive with 100% speed if acceleration button is fully pressed
- */
-constexpr float ACCELERATION_SCALING_FACTOR = 0.35f;
-
-/**
- * @brief scales the absolute deceleration provided by the joystick.
- * Useful if the car should not decelerate with 100% speed if deceleration button is fully pressed
- */
-constexpr float DECELERATION_SCALING_FACTOR = 0.35;
-
-/**
- * @brief scales the absolute steering value (between -1 and 1) provided by the joystick.
- * Useful if the car should not steer 100% left and right
- */
-constexpr float STEERING_SCALING_FACTOR = 0.8f;
-
 class JoystickController
 {
+
+    /**
+     * @brief scales the absolute acceleration provided by the joystick.
+     * Useful if the car should not drive with 100% speed if acceleration button is fully pressed
+     */
+    float m_acceleration_scaling_factor = 0.35f;
+
+    /**
+     * @brief scales the absolute deceleration provided by the joystick.
+     * Useful if the car should not decelerate with 100% speed if deceleration button is fully pressed
+     */
+    float m_deceleration_scaling_factor = 0.35f;
+
+    /**
+     * @brief scales the absolute steering value (between -1 and 1) provided by the joystick.
+     * Useful if the car should not steer 100% left and right
+     */
+    float m_steering_scaling_factor = 0.8f;
+
     struct JoystickMapping
     {
-        int steeringAxis;
-        int accelerationAxis;
-        int decelerationAxis;
-        int enableManualButton;
-        int enableAutonomousButton;
+        uint_fast16_t steeringAxis;
+        uint_fast16_t accelerationAxis;
+        uint_fast16_t decelerationAxis;
+        uint_fast16_t enableManualButton;
+        uint_fast16_t enableAutonomousButton;
     };
 
     const struct JoystickMapping joystick_mapping_ps3 = { 0, 13, 12, 14, 13 };
@@ -51,6 +55,8 @@ class JoystickController
     JoystickController();
 
     private:
+    dynamic_reconfigure::Server<teleoperation::joystick_controllerConfig> m_dyn_cfg_server;
+
     ros::NodeHandle m_node_handle;
     ros::Publisher m_drive_parameter_publisher;
     ros::Subscriber m_joystick_subscriber;
@@ -87,4 +93,9 @@ class JoystickController
      * @brief Looks for a provided joystick_type argument and selects the corresponding JoystickMapping
      */
     void selectJoystickMapping();
+
+    /**
+     * @brief The current value of the members (with regarding to the dyn config) are updated on the server
+     */
+    void updateDynamicConfig();
 };

--- a/ros_ws/src/teleoperation/include/keyboard_controller.h
+++ b/ros_ws/src/teleoperation/include/keyboard_controller.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_keycode.h>
 #include <algorithm>
 #include <array>
 #include <drive_msgs/drive_param.h>
@@ -10,6 +11,9 @@
 #include <std_msgs/Int32.h>
 #include <stdexcept>
 
+#include <dynamic_reconfigure/server.h>
+#include <teleoperation/keyboard_controllerConfig.h>
+
 constexpr const char* TOPIC_DRIVE_PARAMETERS = "input/drive_param/keyboard";
 constexpr const char* TOPIC_HEARTBEAT_MANUAL = "/input/heartbeat_manual";
 constexpr const char* TOPIC_HEARTBEAT_AUTONOMOUS = "/input/heartbeat_autonomous";
@@ -17,15 +21,15 @@ constexpr const char* TOPIC_DRIVE_MODE = "/commands/drive_mode";
 
 enum class Keycode : int
 {
-    W = 119,
-    A = 97,
-    S = 115,
-    D = 100,
-    SPACE = 32,
-    B = 98
+    SPACE = SDLK_SPACE,
+    A = SDLK_a,
+    B = SDLK_b,
+    D = SDLK_d,
+    S = SDLK_s,
+    W = SDLK_w,
 };
 
-enum class KeyIndex : int
+enum class KeyIndex : size_t
 {
     ACCELERATE = 0,
     DECELERATE = 2,
@@ -34,11 +38,6 @@ enum class KeyIndex : int
     ENABLE_MANUAL = 4,
     ENABLE_AUTONOMOUS = 5
 };
-
-constexpr int KEY_COUNT = 6;
-
-constexpr std::array<Keycode, KEY_COUNT> KEY_CODES = { Keycode::W, Keycode::A,     Keycode::S,
-                                                       Keycode::D, Keycode::SPACE, Keycode::B };
 
 enum class DriveMode : int
 {
@@ -49,24 +48,6 @@ enum class DriveMode : int
 
 constexpr double PARAMETER_UPDATE_FREQUENCY = 90;
 
-// How fast the steering value changes, in units per second
-constexpr double STEERING_SPEED = 6;
-// How fast the velocity changes, in units per second
-constexpr double ACCELERATION = 0.4;
-// How fast the velocity changes when decelerating, in units per second
-constexpr double BRAKING = 2;
-
-// MAX_STEERING is multiplied by this when travelling at maximum velocity, by 1.0 when resting and by an interpolated
-// value otherwise
-constexpr double FAST_STEER_LIMIT = 0.6;
-
-// When no steering key is pressed, the steering value will change towards 0 at this rate, in units per second
-constexpr double STEERING_GRAVITY = 2;
-// When no throttle key is pressed, the velocity will change towards 0 at this rate, in units per second
-constexpr double THROTTLE_GRAVITY = 3;
-
-constexpr double MAX_THROTTLE = 0.35;
-
 class KeyboardController
 {
     public:
@@ -76,6 +57,30 @@ class KeyboardController
     ~KeyboardController();
 
     private:
+    // How fast the steering value changes, in units per second
+    double m_steering_speed = 6;
+    // How fast the velocity changes, in units per second
+    double m_acceleration = 0.4;
+    // How fast the velocity changes when decelerating, in units per second
+    double m_braking = 2;
+
+    // MAX_STEERING is multiplied by this when travelling at maximum velocity, by 1.0 when resting and by an
+    // interpolated value otherwise
+    double m_fast_steer_limit = 0.6;
+
+    // When no steering key is pressed, the steering value will change towards 0 at this rate, in units per second
+    double m_steering_gravity = 2;
+    // When no throttle key is pressed, the velocity will change towards 0 at this rate, in units per second
+    double m_throttle_gravity = 3;
+
+    double m_max_throttle = 0.35;
+
+    static constexpr size_t KEY_COUNT = 6;
+    std::array<Keycode, KEY_COUNT> m_key_codes = { { Keycode::W, Keycode::A, Keycode::S, Keycode::D, Keycode::SPACE,
+                                                     Keycode::B } };
+
+    dynamic_reconfigure::Server<teleoperation::keyboard_controllerConfig> m_dyn_cfg_server;
+
     ros::NodeHandle m_node_handle;
 
     ros::Publisher m_drive_parameters_publisher;
@@ -112,4 +117,9 @@ class KeyboardController
     void driveModeCallback(const std_msgs::Int32::ConstPtr& drive_mode_message);
     void updateWindow();
     void loadImages();
+
+    /**
+     * @brief The current value of the members (with regarding to the dyn config) are updated on the server
+     */
+    void updateDynamicConfig();
 };

--- a/ros_ws/src/teleoperation/package.xml
+++ b/ros_ws/src/teleoperation/package.xml
@@ -19,5 +19,6 @@
   <depend>rospy</depend>
   <depend>std_msgs</depend>
   <depend>joy</depend>
+  <depend>dynamic_reconfigure</depend>
 
 </package>


### PR DESCRIPTION
As we discussed, I tired to add dynamic configuration to the teleoperation package. I move some constants like ```STEERING_SPEED``` to the resp. class and declared them as normal members which allows us to change them via dynamic configuration.