### PR TITLE
Using dms_controller for emergency stop

### DIFF
--- a/ros_ws/src/autonomous/wallfollowing1/include/emergency_stop.h
+++ b/ros_ws/src/autonomous/wallfollowing1/include/emergency_stop.h
@@ -7,15 +7,14 @@
 
 #include "drive_msgs/drive_param.h"
 #include "sensor_msgs/LaserScan.h"
-#include "std_msgs/Bool.h"
-#include "std_msgs/Float64.h"
+#include <chrono>
 #include <ros/console.h>
 #include <ros/ros.h>
 
 constexpr float DEG_TO_RAD = M_PI / 180.0;
 
 constexpr const char* TOPIC_LASER_SCAN = "/scan";
-constexpr const char* TOPIC_EMERGENCY_STOP = "/emergency_stop";
+constexpr const char* TOPIC_EMERGENCY_STOP = "/input/emergencystop";
 
 constexpr float RANGE_THRESHOLD = 0.7;
 constexpr const float CAR_BUMPER_LENGTH = 0.2;

--- a/ros_ws/src/autonomous/wallfollowing1/include/wall_following.h
+++ b/ros_ws/src/autonomous/wallfollowing1/include/wall_following.h
@@ -52,12 +52,9 @@ class WallFollowing
     private:
     ros::NodeHandle m_node_handle;
 
-    ros::Subscriber m_emergency_stop_subscriber;
     ros::Subscriber m_lidar_subscriber;
     ros::Publisher m_drive_parameter_publisher;
     RvizGeometryPublisher m_debug_geometry;
-
-    bool m_emergency_stop = true;
 
     PIDController m_pid_controller = PIDController(5, 0.01, 0.2);
 
@@ -65,7 +62,6 @@ class WallFollowing
     void followWalls(const sensor_msgs::LaserScan::ConstPtr& lidar);
     Wall getWall(const sensor_msgs::LaserScan::ConstPtr& lidar, bool right_wall);
 
-    void emergencyStopCallback(const std_msgs::Bool emergency_stop_message);
     void lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar);
     void publishDriveParameters(float velocity, float angle);
 

--- a/ros_ws/src/autonomous/wallfollowing1/src/emergency_stop.cpp
+++ b/ros_ws/src/autonomous/wallfollowing1/src/emergency_stop.cpp
@@ -1,10 +1,11 @@
 #include "emergency_stop.h"
+#include <std_msgs/Int64.h>
 
 EmergencyStop::EmergencyStop()
 {
     m_lidar_subscriber =
         m_node_handle.subscribe<sensor_msgs::LaserScan>(TOPIC_LASER_SCAN, 1, &EmergencyStop::lidarCallback, this);
-    m_emergency_stop_publisher = m_node_handle.advertise<std_msgs::Bool>(TOPIC_EMERGENCY_STOP, 1);
+    m_emergency_stop_publisher = m_node_handle.advertise<std_msgs::Int64>(TOPIC_EMERGENCY_STOP, 1);
 }
 
 bool EmergencyStop::emergencyStop(const sensor_msgs::LaserScan::ConstPtr& lidar)
@@ -44,13 +45,15 @@ void EmergencyStop::lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar)
     if (emergency_stop_active)
     {
         ROS_INFO_STREAM("Wall detected. Emergency stop is active.");
-    }
 
-    std_msgs::Bool message;
-    {
-        message.data = emergency_stop_active;
+        auto now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now());
+        auto time_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+
+        std_msgs::Int64 message;
+        message.data = time_since_epoch.count();
+
+        m_emergency_stop_publisher.publish(message);
     }
-    m_emergency_stop_publisher.publish(message);
 }
 
 int main(int argc, char** argv)

--- a/ros_ws/src/autonomous/wallfollowing1/src/wall_following.cpp
+++ b/ros_ws/src/autonomous/wallfollowing1/src/wall_following.cpp
@@ -6,8 +6,6 @@ WallFollowing::WallFollowing()
 {
     this->m_lidar_subscriber =
         m_node_handle.subscribe<sensor_msgs::LaserScan>(TOPIC_LASER_SCAN, 1, &WallFollowing::lidarCallback, this);
-    this->m_emergency_stop_subscriber =
-        m_node_handle.subscribe<std_msgs::Bool>(TOPIC_EMERGENCY_STOP, 1, &WallFollowing::emergencyStopCallback, this);
     this->m_drive_parameter_publisher = m_node_handle.advertise<drive_msgs::drive_param>(TOPIC_DRIVE_PARAMETERS, 1);
 }
 
@@ -116,21 +114,9 @@ void WallFollowing::publishDriveParameters(float velocity, float angle)
     this->m_drive_parameter_publisher.publish(drive_parameters);
 }
 
-void WallFollowing::emergencyStopCallback(const std_msgs::Bool emergency_stop_message)
-{
-    this->m_emergency_stop = emergency_stop_message.data;
-}
-
 void WallFollowing::lidarCallback(const sensor_msgs::LaserScan::ConstPtr& lidar)
 {
-    if (this->m_emergency_stop == false)
-    {
-        this->followWalls(lidar);
-    }
-    else
-    {
-        this->publishDriveParameters(0, 0);
-    }
+    this->followWalls(lidar);
 }
 
 int main(int argc, char** argv)

--- a/ros_ws/src/car_control/include/dms_controller.h
+++ b/ros_ws/src/car_control/include/dms_controller.h
@@ -41,7 +41,7 @@ class DMSController
     /**
      * @brief How long the dead man's switch blocks all inputs, after receving an emergency stop message
      */
-    std::chrono::duration<double> m_emergencystop_exploration_time;
+    std::chrono::duration<double> m_emergencystop_expiration_time;
 
     std::chrono::steady_clock::time_point m_last_heartbeat_manual;
     std::chrono::steady_clock::time_point m_last_heartbeat_autonomous;

--- a/ros_ws/src/car_control/include/dms_controller.h
+++ b/ros_ws/src/car_control/include/dms_controller.h
@@ -9,10 +9,12 @@
 
 constexpr const char* PARAMETER_DMS_CHECK_RATE = "dms_check_rate";
 constexpr const char* PARAMETER_DMS_EXPIRATION = "dms_expiration";
+constexpr const char* PARAMETER_EMERGENCYSTOP_EXPIRATION = "emergencystop_expiration";
 constexpr const char* PARAMETER_MODE_OVERRIDE = "mode_override";
 
 constexpr const char* TOPIC_HEARTBEAT_MANUAL = "/input/heartbeat_manual";
 constexpr const char* TOPIC_HEARTBEAT_AUTONOMOUS = "/input/heartbeat_autonomous";
+constexpr const char* TOPIC_EMERGENCYSTOP = "/input/emergencystop";
 constexpr const char* TOPIC_DRIVE_MODE = "/commands/drive_mode";
 
 constexpr DriveMode NO_OVERRIDE = DriveMode::LOCKED;
@@ -36,13 +38,19 @@ class DMSController
      * @brief How old the last dead man's switch heartbeat can be, in ms
      */
     std::chrono::duration<double> m_expiration_time;
+    /**
+     * @brief How long the dead man's switch blocks all inputs, after receving an emergency stop message
+     */
+    std::chrono::duration<double> m_emergencystop_exploration_time;
 
     std::chrono::steady_clock::time_point m_last_heartbeat_manual;
     std::chrono::steady_clock::time_point m_last_heartbeat_autonomous;
+    std::chrono::steady_clock::time_point m_last_emergencystop;
 
     ros::NodeHandle m_node_handle;
     ros::Subscriber m_heartbeat_manual_subscriber;
     ros::Subscriber m_heartbeat_autonomous_subscriber;
+    ros::Subscriber m_emergencystop_subscriber;
     ros::Publisher m_drive_mode_publisher;
 
     void configureParameters();
@@ -50,5 +58,6 @@ class DMSController
 
     void heartbeatManualCallback(const std_msgs::Int64::ConstPtr& dms_message);
     void heartbeatAutonomousCallback(const std_msgs::Int64::ConstPtr& dms_message);
+    void emergencystopCallback(const std_msgs::Int64::ConstPtr& dms_message);
     DriveMode getDriveMode();
 };

--- a/ros_ws/src/car_control/launch/car_control.launch
+++ b/ros_ws/src/car_control/launch/car_control.launch
@@ -6,6 +6,7 @@ Launches all necessary nodes that listen for drive_parameters and translate them
     <arg name="mode_override" default="0"/>
     <arg name="dms_check_rate" default="20" /> <!-- in Hz -->
     <arg name="dms_expiration" default="100" /> <!-- in ms -->
+    <arg name="emergencystop_expiration" default="3000" /> <!-- in ms -->
 	
     <!-- car control node -->
     <node
@@ -25,6 +26,7 @@ Launches all necessary nodes that listen for drive_parameters and translate them
       output="screen" >
       <param name="dms_check_rate" type="int" value = "$(arg dms_check_rate)" />
       <param name="dms_expiration" type="int" value = "$(arg dms_expiration)" />
+      <param name="emergencystop_expiration" type="int" value = "$(arg emergencystop_expiration)" />
       <param name="mode_override" type="int" value = "$(arg mode_override)" />
     </node>
 

--- a/ros_ws/src/car_control/src/dms_controller.cpp
+++ b/ros_ws/src/car_control/src/dms_controller.cpp
@@ -37,7 +37,7 @@ DriveMode DMSController::getDriveMode()
     }
 
     auto current_time = std::chrono::steady_clock::now();
-    if (this->m_last_emergencystop + this->m_emergencystop_exploration_time > current_time)
+    if (this->m_last_emergencystop + this->m_emergencystop_expiration_time > current_time)
     {
         return DriveMode::LOCKED;
     }
@@ -102,15 +102,15 @@ void DMSController::configureParameters()
     this->m_expiration_time = std::chrono::duration<double>(expiration_ms / 1000.0);
 
     // configure emergency stop exploration time
-    int emergencystop_exploration_time;
-    private_node_handle.getParam(PARAMETER_EMERGENCYSTOP_EXPIRATION, emergencystop_exploration_time);
-    if (emergencystop_exploration_time <= 0 || emergencystop_exploration_time > 10000)
+    int emergencystop_expiration_time;
+    private_node_handle.getParam(PARAMETER_EMERGENCYSTOP_EXPIRATION, emergencystop_expiration_time);
+    if (emergencystop_expiration_time <= 0 || emergencystop_expiration_time > 10000)
     {
         ROS_WARN_STREAM("emergencystop_expiration should be between 0 and 10000. Your value: "
-                        << emergencystop_exploration_time << ", using default: 3000.");
-        emergencystop_exploration_time = 3000;
+                        << emergencystop_expiration_time << ", using default: 3000.");
+        emergencystop_expiration_time = 3000;
     }
-    this->m_emergencystop_exploration_time = std::chrono::duration<double>(emergencystop_exploration_time / 1000.0);
+    this->m_emergencystop_expiration_time = std::chrono::duration<double>(emergencystop_expiration_time / 1000.0);
 
     // configure mode override parameter
     int mode_override_parameter;


### PR DESCRIPTION
The dms_controller now listens for messages in topic "/input/emergencystop".
If a message with an timestamp arrives on this topic, the dms controller locks itself for (default) 3000ms.

To test this you have to switch to wallfollowing1 inside the gazebo.launch , since wallfollowing2 has no emergencystop right now.