### PR TITLE
Car odometry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ros_ws/src/external_packages/vesc"]
 	path = ros_ws/src/external_packages/vesc
-	url = https://github.com/mit-racecar/vesc.git
+	url = https://github.uconn.edu/ret15108/vesc

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
         - source /opt/ros/${ROS_DISTRO}/setup.bash
         - catkin_make 
         - catkin_make run_tests && catkin_test_results
+        - ./../scripts/travis/check-consistency.sh || travis_terminate 1
       
     - # create documentation
       if: type != pull_request AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
             - python-wstool
             - libsdl2-dev
             - clang-format-3.8
+            - libyaml-cpp0.5v5
 
       cache:
           apt: true

--- a/ros_ws/launch/car.launch
+++ b/ros_ws/launch/car.launch
@@ -9,26 +9,16 @@
     </include>
 
     <include file="$(find vesc_driver)/launch/vesc_driver_node.launch"/>
-    
+
     <rosparam command="load" file="$(find vesc_sim)/config/car_config.yaml"/>
 
     <include file="$(find vesc_ackermann)/launch/vesc_to_odom_node.launch"/>
-
-    <!-- Passing parameters to the vesc_to_odom node doesn't currently work-->
-    <!--<node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom_node"
-        output="screen" launch-prefix="" >
-        <param name="speed_to_erpm_gain" value="64.96"/>
-        <param name="speed_to_erpm_offset" value="0"/>
-        <param name="steering_angle_to_servo_gain" value="-0.95492965"/>
-        <param name="steering_angle_to_servo_offset" value="0.5"/>
-        <param name="wheelbase" value="0.325"/>
-    </node>-->
 
     <include file="$(find wallfollowing1)/launch/autonomous_driving.launch"/>
 
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find car_control)/launch/car.rviz"/>
 
     <node pkg="urg_node" type="urg_node" name="urg_node">
-        <param name="_ip_address"  value="192.168.1.10"/>
+        <param name="_ip_address" value="192.168.1.10"/>
     </node>
 </launch>

--- a/ros_ws/launch/car.launch
+++ b/ros_ws/launch/car.launch
@@ -10,6 +10,10 @@
 
     <include file="$(find vesc_driver)/launch/vesc_driver_node.launch"/>
     
+    <rosparam command="load" file="$(find vesc_sim)/config/car_config.yaml"/>
+
+    <include file="$(find vesc_ackermann)/launch/vesc_to_odom_node.launch"/>
+
     <!-- Passing parameters to the vesc_to_odom node doesn't currently work-->
     <!--<node pkg="vesc_ackermann" type="vesc_to_odom_node" name="vesc_to_odom_node"
         output="screen" launch-prefix="" >

--- a/ros_ws/src/simulation/vesc_sim/CMakeLists.txt
+++ b/ros_ws/src/simulation/vesc_sim/CMakeLists.txt
@@ -9,6 +9,7 @@ set (CMAKE_CXX_STANDARD 11)
 find_package(catkin REQUIRED COMPONENTS
   drive_msgs
   roscpp
+  roslib
   rospy
   std_msgs
   vesc_msgs
@@ -16,7 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   tf
 )
-
+find_package(yaml-cpp REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -25,7 +26,8 @@ find_package(catkin REQUIRED COMPONENTS
 ## Declare things to be passed to dependent projects
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS drive_msgs roscpp rospy std_msgs vesc_msgs nav_msgs geometry_msgs tf
+  CATKIN_DEPENDS drive_msgs roscpp roslib rospy std_msgs vesc_msgs nav_msgs geometry_msgs tf
+  DEPENDS yaml-cpp
 )
 
 ## Errors and Warnings
@@ -40,6 +42,7 @@ set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${YAML_CPP_INCLUDE_DIRS}
 )
 
 # Declare joystick controller node executable
@@ -51,3 +54,7 @@ src/vesc_sim.cpp
 
 target_link_libraries(vesc_sim_driver ${catkin_LIBRARIES})
 add_dependencies(vesc_sim_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+add_executable(params_to_yaml src/params_to_yaml.cpp)
+target_link_libraries(params_to_yaml ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
+add_dependencies(params_to_yaml ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/ros_ws/src/simulation/vesc_sim/config/car_config.yaml
+++ b/ros_ws/src/simulation/vesc_sim/config/car_config.yaml
@@ -1,0 +1,5 @@
+speed_to_erpm_gain: 64.9612012619981
+speed_to_erpm_offset: 0
+steering_angle_to_servo_gain: -0.954929658551372
+steering_angle_to_servo_offset: 0.5
+wheelbase: 0.325

--- a/ros_ws/src/simulation/vesc_sim/package.xml
+++ b/ros_ws/src/simulation/vesc_sim/package.xml
@@ -14,9 +14,12 @@
   <!-- Dependencies -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>yaml-cpp</build_depend>
+
   <depend>drive_msgs</depend>
   <depend>std_msgs</depend>
   <depend>roscpp</depend>
+  <depend>roslib</depend>
   <depend>rospy</depend>
   <depend>nav_msgs</depend>
   <depend>vesc_msgs</depend>

--- a/ros_ws/src/simulation/vesc_sim/src/params_to_yaml.cpp
+++ b/ros_ws/src/simulation/vesc_sim/src/params_to_yaml.cpp
@@ -1,0 +1,18 @@
+#include "car_config.h"
+#include "yaml-cpp/yaml.h"
+#include <fstream>
+#include <ros/package.h>
+
+int main(int argc, char** argv)
+{
+    YAML::Node node;
+    node["speed_to_erpm_gain"] = car_config::SPEED_TO_ERPM;
+    node["speed_to_erpm_offset"] = 0;
+    node["steering_angle_to_servo_gain"] = car_config::STEERING_TO_SERVO_GAIN;
+    node["steering_angle_to_servo_offset"] = car_config::STEERING_TO_SERVO_OFFSET;
+    node["wheelbase"] = car_config::WHEELBASE;
+
+    std::string package_path = ros::package::getPath("vesc_sim");
+    std::ofstream fout(package_path + "/config/car_config.yaml");
+    fout << node;
+}

--- a/scripts/travis/check-consistency.sh
+++ b/scripts/travis/check-consistency.sh
@@ -5,5 +5,5 @@ source $pathofscript/../../ros_ws/devel/setup.bash
 
 mv $pathofvescsim/config/car_config.yaml $pathofvescsim/config/car_config_copy.yaml || { echo 'Could not find "car_config.yaml" in package "vesc_sim".' ; exit 1; }
 rosrun vesc_sim params_to_yaml
-cmp -s $pathofvescsim/config/car_config.yaml $pathofvescsim/config/car_config_copy.yaml || { echo 'Inconsisteny between "vesc_sim/include/car_config.h" and "vesc_sim/config/car_config.yaml" detected. Please run "rosrun vesc_sim params_to_yaml" to fix this.' ; exit 0; }
+cmp -s $pathofvescsim/config/car_config.yaml $pathofvescsim/config/car_config_copy.yaml || { echo 'Inconsisteny between "vesc_sim/include/car_config.h" and "vesc_sim/config/car_config.yaml" detected. Please run "rosrun vesc_sim params_to_yaml" to fix this.' ; exit 1; }
 rm $pathofvescsim/config/car_config_copy.yaml

--- a/scripts/travis/check-consistency.sh
+++ b/scripts/travis/check-consistency.sh
@@ -1,0 +1,2 @@
+pathofscript=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+echo $pathofscript

--- a/scripts/travis/check-consistency.sh
+++ b/scripts/travis/check-consistency.sh
@@ -1,2 +1,9 @@
 pathofscript=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-echo $pathofscript
+pathofvescsim=$pathofscript/../../ros_ws/src/simulation/vesc_sim
+
+source $pathofscript/../../ros_ws/devel/setup.bash
+
+mv $pathofvescsim/config/car_config.yaml $pathofvescsim/config/car_config_copy.yaml || { echo 'Could not find "car_config.yaml" in package "vesc_sim".' ; exit 1; }
+rosrun vesc_sim params_to_yaml
+cmp -s $pathofvescsim/config/car_config.yaml $pathofvescsim/config/car_config_copy.yaml || { echo 'Inconsisteny between "vesc_sim/include/car_config.h" and "vesc_sim/config/car_config.yaml" detected. Please run "rosrun vesc_sim params_to_yaml" to fix this.' ; exit 0; }
+rm $pathofvescsim/config/car_config_copy.yaml


### PR DESCRIPTION
Adds/Readds odometry for the actual car.

Notable changes:
- Removed the (outdated) vesc submodule and added the updated vesc package from https://github.uconn.edu/ret15108/vesc
- Added a params_to_yaml rosnode to convert the car_config header into a .yaml file because ROS can only read .yaml files (maybe the parameters should be saved as a yaml and converted into a header instead?)
- Added travis check for consistency between yaml and header file