### PR TITLE
Exclude submodules from format check

### DIFF
--- a/scripts/format/format-src.sh
+++ b/scripts/format/format-src.sh
@@ -3,4 +3,4 @@ cd "$(dirname ${BASH_SOURCE[0]})"
 
 ./clang-format-script.sh ../../ros_ws/ file
 
-autopep8 --in-place --recursive --aggressive --aggressive ../../ros_ws/
+autopep8 --in-place --recursive --aggressive --aggressive --exclude="../../ros_ws/src/external_packages,../../ros_ws/build,../../ros_ws/devel" ../../ros_ws/

--- a/scripts/travis/check-format.sh
+++ b/scripts/travis/check-format.sh
@@ -10,7 +10,7 @@ do
 done
 
 # Check python code
-PYTHON_DIFF=$(autopep8 --diff --recursive --aggressive --aggressive .)
+PYTHON_DIFF=$(autopep8 --diff --recursive --aggressive --aggressive --exclude="./ros_ws/src/external_packages,./ros_ws/build,./ros_ws/devel" .)
 
 if echo $PYTHON_DIFF | grep -c +++ > /dev/null ; then
     echo "Found formatting problems in the python code."


### PR DESCRIPTION
Also excluded `build` and `devel` folders for good measure.