### PR TITLE
Fix travis check_format script to always use correct path

### DIFF
--- a/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
+++ b/ros_ws/src/car_control/include/drive_parameters_multiplexer.h
@@ -15,8 +15,9 @@ constexpr const char* TOPIC_DRIVE_PARAMETERS_AUTONOMOUS = "input/drive_param/aut
 constexpr const char* TOPIC_DRIVE_MODE = "/commands/drive_mode";
 
 /*
-* This node subscribes to all publishers that send drive_param messages and selects one to forward to the car controller
-*/
+ * This node subscribes to all publishers that send drive_param messages and selects one to forward to the car
+ * controller
+ */
 class DriveParametersMultiplexer
 {
     public:

--- a/ros_ws/src/car_control/include/drive_parameters_source.h
+++ b/ros_ws/src/car_control/include/drive_parameters_source.h
@@ -14,8 +14,8 @@ using DriveParameterCallbackFunction =
 constexpr float IDLE_RANGE = 0.01f;
 
 /*
-*  A class that listens on a topic that publishes drive parameters and stores information about that source
-*/
+ *  A class that listens on a topic that publishes drive parameters and stores information about that source
+ */
 class DriveParametersSource
 {
     public:

--- a/scripts/travis/check-format.sh
+++ b/scripts/travis/check-format.sh
@@ -1,7 +1,9 @@
+workspace_path=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../../ros_ws
+
 FOUND_PROBLEMS=false
 
 # Check C++ code
-for FILE in $(find "./" -path './src/external_packages' -prune -o \( -name '*.h' -or -name '*.cpp' \) -print)
+for FILE in $(find "$workspace_path" -path '$workspace_path/src/external_packages' -prune -o \( -name '*.h' -or -name '*.cpp' \) -print)
 do
     if clang-format-3.8 -i -style=file -output-replacements-xml $FILE | grep -c "<replacement " > /dev/null ; then
         echo "Formatting problem in:" $FILE
@@ -10,7 +12,7 @@ do
 done
 
 # Check python code
-PYTHON_DIFF=$(autopep8 --diff --recursive --aggressive --aggressive --exclude="./ros_ws/src/external_packages,./ros_ws/build,./ros_ws/devel" .)
+PYTHON_DIFF=$(autopep8 --diff --recursive --aggressive --aggressive --exclude="$workspace_path/src/external_packages,$workspace_path/build,$workspace_path/devel" $workspace_path)
 
 if echo $PYTHON_DIFF | grep -c +++ > /dev/null ; then
     echo "Found formatting problems in the python code."

--- a/scripts/travis/check-format.sh
+++ b/scripts/travis/check-format.sh
@@ -3,7 +3,7 @@ workspace_path=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../../ros_ws
 FOUND_PROBLEMS=false
 
 # Check C++ code
-for FILE in $(find "$workspace_path" -path '$workspace_path/src/external_packages' -prune -o \( -name '*.h' -or -name '*.cpp' \) -print)
+for FILE in $(find "$workspace_path" -path '*ros_ws/src/external_packages' -prune -o \( -name '*.h' -or -name '*.cpp' \) -print)
 do
     if clang-format-3.8 -i -style=file -output-replacements-xml $FILE | grep -c "<replacement " > /dev/null ; then
         echo "Formatting problem in:" $FILE


### PR DESCRIPTION
Because of an error I've made with file paths PR #268 did not work the way it was expected. This PR fixes that by using file paths relative to the script file instead of relative to the current working directory.