### PR TITLE
Added "required" arg to critical nodes

### DIFF
--- a/ros_ws/src/autonomous/emergency_stop/launch/emergency_stop.launch
+++ b/ros_ws/src/autonomous/emergency_stop/launch/emergency_stop.launch
@@ -4,11 +4,10 @@
 
     <!-- emergency_stop node -->
     <node
-      respawn="true"
       pkg="emergency_stop"
       type="emergency_stop"
       name="emergency_stop"
-      output="screen" >
-    </node>
+      output="screen" 
+      required="true" />
 
 </launch>

--- a/ros_ws/src/car_control/launch/car_control.launch
+++ b/ros_ws/src/car_control/launch/car_control.launch
@@ -10,20 +10,19 @@ Launches all necessary nodes that listen for drive_parameters and translate them
 	
     <!-- car control node -->
     <node
-      respawn="true"
       pkg="car_control"
       type="car_controller"
       name="car_controller"
-      output="screen" >
-    </node>
+      output="screen"
+      required="true" />
 
     <!-- dms control node -->
     <node
-      respawn="true"
       pkg="car_control"
       type="dms_controller"
       name="dms_controller"
-      output="screen" >
+      output="screen"
+      required="true" >
       <param name="dms_check_rate" type="int" value = "$(arg dms_check_rate)" />
       <param name="dms_expiration" type="int" value = "$(arg dms_expiration)" />
       <param name="emergencystop_expiration" type="int" value = "$(arg emergencystop_expiration)" />
@@ -32,11 +31,10 @@ Launches all necessary nodes that listen for drive_parameters and translate them
 
     <!-- Drive Parameters Multiplexer node -->
     <node
-      respawn="true"
       pkg="car_control"
       type="drive_parameters_multiplexer"
       name="drive_parameters_multiplexer"
-      output="screen" >
-    </node>
+      output="screen"
+      required="true" />
 	
 </launch>


### PR DESCRIPTION
For safety reasons, ROS should abort if a critical node like the emergency stop fails.