### PR TITLE
Warn if the wallfollowing node receives a laser scan with no valid data

### DIFF
--- a/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
+++ b/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
@@ -182,6 +182,11 @@ def follow_walls(left_circle, right_circle, barrier, delta_time):
 
 def handle_scan(laser_scan, delta_time):
     points = get_scan_as_cartesian(laser_scan)
+
+    if points.shape[0] == 0:
+        rospy.logwarn("Skipping current laser scan message since it contains no finite values.")  # nopep8
+        return
+
     split = find_left_right_border(points)
 
     right_wall = points[:split:4, :]


### PR DESCRIPTION
Currently, this will raise an exception. This PR catches the exception and logs a warning.