### PR TITLE
Fix bugs related to resetting the Gazebo simulation

### DIFF
--- a/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
+++ b/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
@@ -211,7 +211,7 @@ def laser_callback(scan_message):
     global last_scan
 
     scan_time = scan_message.header.stamp.to_sec()
-    if last_scan is not None and abs(scan_time - last_scan) > 0.0001:
+    if last_scan is not None and abs(scan_time - last_scan) > 0.0001 and scan_time > last_scan:  # nopep8
         delta_time = scan_time - last_scan
         handle_scan(scan_message, delta_time)
 

--- a/ros_ws/src/car_control/src/dms_controller.cpp
+++ b/ros_ws/src/car_control/src/dms_controller.cpp
@@ -37,16 +37,19 @@ DriveMode DMSController::getDriveMode()
     }
 
     auto current_time = ros::Time::now();
-    if (this->m_last_heartbeat_manual + this->m_expiration_time > current_time)
+    if (this->m_last_heartbeat_manual + this->m_expiration_time > current_time &&
+        this->m_last_heartbeat_manual < current_time)
     {
         return DriveMode::MANUAL;
     }
     if (!this->m_last_emergencystop.is_zero() &&
-        this->m_last_emergencystop + this->m_emergencystop_expiration_time > current_time)
+        this->m_last_emergencystop + this->m_emergencystop_expiration_time > current_time &&
+        this->m_last_emergencystop < current_time)
     {
         return DriveMode::LOCKED;
     }
-    if (this->m_last_heartbeat_autonomous + this->m_expiration_time > current_time)
+    if (this->m_last_heartbeat_autonomous + this->m_expiration_time > current_time &&
+        this->m_last_heartbeat_autonomous < current_time)
     {
         return DriveMode::AUTONOMOUS;
     }


### PR DESCRIPTION
Bugs fixed:
- When resetting the Gazebo simulation, a drive mode would be enabled, even if the corresponding button is not pressed
- When resetting the Gazebo simulation, wallfollowing stops working